### PR TITLE
URL encode query expression when using it as API search term

### DIFF
--- a/Classes/Service/PixxioClient.php
+++ b/Classes/Service/PixxioClient.php
@@ -163,7 +163,7 @@ final class PixxioClient
         $options->fileType = implode(',', $fileTypes);
 
         if (!empty($queryExpression)) {
-            $options->searchTerm = $queryExpression;
+            $options->searchTerm = urlencode($queryExpression);
         }
 
         if (isset($orderings['filename'])) {


### PR DESCRIPTION
This prevents "400 bad request" API errors when sending search terms containing e.g. spaces from the Neos backend