### PR TITLE
BUGFIX: Use proper title

### DIFF
--- a/Classes/AssetSource/PixxioAssetProxy.php
+++ b/Classes/AssetSource/PixxioAssetProxy.php
@@ -122,8 +122,7 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
         $assetProxy->fileSize = $jsonObject->fileSize;
         $assetProxy->mediaType = MediaTypes::getMediaTypeFromFilename('foo.' . $modifiedFileType);
 
-#        $assetProxy->iptcProperties['Title'] = $jsonObject->subject ?? '';
-        $assetProxy->iptcProperties['Title'] = $usePixxioThumbnailAsOriginal  ? 'YES' : 'NO';
+        $assetProxy->iptcProperties['Title'] = $jsonObject->subject ?? '';
         $assetProxy->iptcProperties['CaptionAbstract'] = $jsonObject->description ?? '';
 
         $assetProxy->widthInPixels = $jsonObject->imageWidth ?? null;


### PR DESCRIPTION
Currently the title "YES" or "NO" is imported.
Was probably overwritten for debugging.