### PR TITLE
Add dynamicMetadata and enable rendering of CopyrightNotices in Neos 

### DIFF
--- a/Classes/AssetSource/PixxioAssetProxy.php
+++ b/Classes/AssetSource/PixxioAssetProxy.php
@@ -124,6 +124,7 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
 
         $assetProxy->iptcProperties['Title'] = $jsonObject->subject ?? '';
         $assetProxy->iptcProperties['CaptionAbstract'] = $jsonObject->description ?? '';
+        $assetProxy->iptcProperties['CopyrightNotice'] = $jsonObject->dynamicMetadata->CopyrightNotice ?? '';
 
         $assetProxy->widthInPixels = $jsonObject->imageWidth ?? null;
         $assetProxy->heightInPixels = $jsonObject->imageHeight ?? null;

--- a/Classes/Service/PixxioClient.php
+++ b/Classes/Service/PixxioClient.php
@@ -57,7 +57,7 @@ final class PixxioClient
      */
     private $fields = [
         'id', 'originalFilename', 'fileType', 'keywords', 'createDate', 'imageHeight', 'imageWidth', 'originalPath', 'subject', 'description',
-        'modifyDate', 'fileSize', 'modifiedImagePaths', 'imagePath'
+        'modifyDate', 'fileSize', 'modifiedImagePaths', 'imagePath', 'dynamicMetadata'
     ];
 
 


### PR DESCRIPTION
The field _dynamicMetadata_ was added and an additional iptcProperty was inserted to display _CopyrightNotices_ in Neos (_CopyrightNotices_ have to be enabled in the pixx.io settings first).