### PR TITLE
FEATURE: Add apiClientOptions to configuration

### DIFF
--- a/Classes/AssetSource/PixxioAssetProxy.php
+++ b/Classes/AssetSource/PixxioAssetProxy.php
@@ -15,6 +15,8 @@ namespace Flownative\Pixxio\AssetSource;
 
 use Behat\Transliterator\Transliterator;
 use Exception;
+use Flownative\Pixxio\Exception\ConnectionException;
+use GuzzleHttp\Client;
 use Neos\Flow\Http\Uri;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\HasRemoteOriginalInterface;
@@ -287,7 +289,17 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
      */
     public function getImportStream()
     {
-        return fopen($this->originalUri, 'rb');
+        $client = new Client($this->assetSource->getAssetSourceOptions()['apiClientOptions'] ?? []);
+        try {
+            $response = $client->request('GET', $this->originalUri);
+            if ($response->getStatusCode() === 200) {
+                return $response->getBody()->detach();
+            } else {
+                return false;
+            }
+        } catch (GuzzleException $e) {
+            throw new ConnectionException('Retrieving file failed: ' . $e->getMessage(), 1542808207);
+        }
     }
 
     /**

--- a/Classes/AssetSource/PixxioAssetSource.php
+++ b/Classes/AssetSource/PixxioAssetSource.php
@@ -68,6 +68,11 @@ class PixxioAssetSource implements AssetSourceInterface
     private $apiKey;
 
     /**
+     * @var array
+     */
+    private $apiClientOptions = [];
+
+    /**
      * @var string
      */
     private $sharedRefreshToken;
@@ -117,6 +122,12 @@ class PixxioAssetSource implements AssetSourceInterface
                     }
                     $this->apiKey = $optionValue;
                 break;
+                case 'apiClientOptions':
+                    if (!is_array($optionValue) || empty($optionValue)) {
+                        throw new \InvalidArgumentException(sprintf('Invalid api client options specified for Pixx.io asset source %s', $assetSourceIdentifier), 1591605348);
+                    }
+                    $this->apiClientOptions = $optionValue;
+                    break;
                 case 'sharedRefreshToken':
                     if (!is_string($optionValue) || empty($optionValue)) {
                         throw new \InvalidArgumentException(sprintf('Invalid shared refresh token specified for Pixx.io asset source %s', $assetSourceIdentifier), 1528806843);
@@ -257,7 +268,8 @@ class PixxioAssetSource implements AssetSourceInterface
             $this->pixxioClient = $this->pixxioServiceFactory->createForAccount(
                 $account->getAccountIdentifier(),
                 $this->apiEndpointUri,
-                $this->apiKey
+                $this->apiKey,
+                $this->apiClientOptions
             );
 
             $this->pixxioClient->authenticate($clientSecret->getRefreshToken());

--- a/Classes/AssetSource/PixxioAssetSource.php
+++ b/Classes/AssetSource/PixxioAssetSource.php
@@ -123,7 +123,7 @@ class PixxioAssetSource implements AssetSourceInterface
                     $this->apiKey = $optionValue;
                 break;
                 case 'apiClientOptions':
-                    if (!is_array($optionValue) || empty($optionValue)) {
+                    if (!is_array($optionValue)) {
                         throw new \InvalidArgumentException(sprintf('Invalid api client options specified for Pixx.io asset source %s', $assetSourceIdentifier), 1591605348);
                     }
                     $this->apiClientOptions = $optionValue;

--- a/Classes/Service/PixxioClient.php
+++ b/Classes/Service/PixxioClient.php
@@ -44,6 +44,11 @@ final class PixxioClient
     private $apiKey;
 
     /**
+     * @var array
+     */
+    private $apiClientOptions;
+
+    /**
      * @var string
      */
     private $accessToken;
@@ -65,12 +70,14 @@ final class PixxioClient
     /**
      * @param string $apiEndpointUri
      * @param string $apiKey
+     * @param array $apiClientOptions
      */
-    public function __construct(string $apiEndpointUri, string $apiKey)
+    public function __construct(string $apiEndpointUri, string $apiKey, array $apiClientOptions)
     {
         $this->apiEndpointUri = $apiEndpointUri;
         $this->apiKey = $apiKey;
-        $this->guzzleClient = new Client();
+        $this->apiClientOptions = $apiClientOptions;
+        $this->guzzleClient = new Client($this->apiClientOptions);
         $this->imageOptions  = [
             (object)[
                 'width' => 400,
@@ -136,7 +143,7 @@ final class PixxioClient
             'options=' . \GuzzleHttp\json_encode($options)
         );
 
-        $client = new Client();
+        $client = new Client($this->apiClientOptions);
         try {
             return $client->request('GET', $uri);
         } catch (GuzzleException $e) {
@@ -164,7 +171,7 @@ final class PixxioClient
             'accessToken=' . $this->accessToken
         );
 
-        $client = new Client();
+        $client = new Client($this->apiClientOptions);
         try {
             return $client->request(
                 'PUT',
@@ -219,7 +226,7 @@ final class PixxioClient
             'options=' . \GuzzleHttp\json_encode($options)
         );
 
-        $client = new Client();
+        $client = new Client($this->apiClientOptions);
         try {
             return $client->request('GET', $uri);
         } catch (GuzzleException $e) {

--- a/Classes/Service/PixxioServiceFactory.php
+++ b/Classes/Service/PixxioServiceFactory.php
@@ -42,13 +42,15 @@ class PixxioServiceFactory
      * @param string $accountIdentifier
      * @param string $apiEndpointUri
      * @param string $apiKey
+     * @param array $apiClientOptions
      * @return PixxioClient
      */
-    public function createForAccount(string $accountIdentifier, string $apiEndpointUri, string $apiKey)
+    public function createForAccount(string $accountIdentifier, string $apiEndpointUri, string $apiKey, array $apiClientOptions)
     {
         $client = new PixxioClient(
             $apiEndpointUri,
-            $apiKey
+            $apiKey,
+            $apiClientOptions
         );
         return $client;
     }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -19,6 +19,11 @@ Neos:
           # Please get in touch with Pixx.io support in order to get this key.
           apiKey: ''
 
+          # Options for the Guzzle HTTP Client as specified here
+          # see http://docs.guzzlephp.org/en/6.5/request-options.html
+          # Use this to configure custom certificates or to disable cert verification
+          apiClientOptions: {}
+
           # A pixx.io user refresh token which is shared across all editors in
           # this Neos installation.
           # sharedRefreshToken: ''

--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ Neos:
               usePixxioThumbnailAsOriginal: true
 ```
 
+Sometimes the API Client needs additional configuration for the tls connection
+like custom timeouts or certificates. 
+See: http://docs.guzzlephp.org/en/6.5/request-options.html
+
+```yaml
+Neos:
+  Media:
+    assetSources:
+      'flownative-pixxio':
+        assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
+        assetSourceOptions:
+          apiClientOptions: 
+            'verify': '/path/to/cert.pem'           
+```
+
 ## Run database migrations
 ```bash
 ./flow doctrine:migrate


### PR DESCRIPTION
The options are used for the Guzzle HTTP Client as is documented here: http://docs.guzzlephp.org/en/6.5/request-options.html

Use this to configure custom certificates, timeouts or to disable cert verification