### PR TITLE
Support asset collections for filtering

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.md]
+trim_trailing_whitespace = false

--- a/Classes/AssetSource/PixxioAssetProxyQuery.php
+++ b/Classes/AssetSource/PixxioAssetProxyQuery.php
@@ -45,6 +45,11 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
     private $assetTypeFilter = 'All';
 
     /**
+     * @var ?string
+     */
+    private $assetCollectionFilter;
+
+    /**
      * @var array
      */
     private $orderings = [];
@@ -146,6 +151,22 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
     public function getAssetTypeFilter(): string
     {
         return $this->assetTypeFilter;
+    }
+
+    /**
+     * @param ?string $assetCollectionFilter
+     */
+    public function setAssetCollectionFilter(?string $assetCollectionFilter): void
+    {
+        $this->assetCollectionFilter = $assetCollectionFilter;
+    }
+
+    /**
+     * @return ?string
+     */
+    public function getAssetCollectionFilter(): ?string
+    {
+        return $this->assetCollectionFilter;
     }
 
     /**
@@ -282,6 +303,6 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
             break;
         }
 
-        return $this->assetSource->getPixxioClient()->search($searchTerm, $formatTypes, $fileTypes, $this->offset, $limit, $orderings);
+        return $this->assetSource->getPixxioClient()->search($searchTerm, $formatTypes, $fileTypes, $this->assetCollectionFilter, $this->offset, $limit, $orderings);
     }
 }

--- a/Classes/AssetSource/PixxioAssetProxyQueryResult.php
+++ b/Classes/AssetSource/PixxioAssetProxyQueryResult.php
@@ -103,7 +103,6 @@ class PixxioAssetProxyQueryResult implements AssetProxyQueryResultInterface
     {
         $this->initialize();
         return $this->assetProxiesIterator->key();
-
     }
 
     public function valid()
@@ -142,15 +141,18 @@ class PixxioAssetProxyQueryResult implements AssetProxyQueryResultInterface
 
     /**
      * @return int
+     * @throws \Flownative\Pixxio\Exception\ConnectionException
      */
     public function count(): int
     {
         if ($this->numberOfAssetProxies === null) {
             if (is_array($this->assetProxies)) {
-                return count($this->assetProxies);
+                $this->numberOfAssetProxies = count($this->assetProxies);
             } else {
-                return $this->query->count();
+                $this->numberOfAssetProxies = $this->query->count();
             }
         }
+
+        return $this->numberOfAssetProxies;
     }
 }

--- a/Classes/AssetSource/PixxioAssetProxyRepository.php
+++ b/Classes/AssetSource/PixxioAssetProxyRepository.php
@@ -20,7 +20,6 @@ use Flownative\Pixxio\Exception\AuthenticationFailedException;
 use Flownative\Pixxio\Exception\ConnectionException;
 use Flownative\Pixxio\Exception\MissingClientSecretException;
 use Neos\Cache\Frontend\StringFrontend;
-use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Media\Domain\Model\AssetSource\AssetNotFoundExceptionInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
@@ -42,14 +41,6 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
     private $assetSource;
 
     /**
-     * @param PixxioAssetSource $assetSource
-     */
-    public function __construct(PixxioAssetSource $assetSource)
-    {
-        $this->assetSource = $assetSource;
-    }
-
-    /**
      * @var string
      */
     private $assetTypeFilter = 'All';
@@ -63,6 +54,14 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
      * @var StringFrontend
      */
     protected $assetProxyCache;
+
+    /**
+     * @param PixxioAssetSource $assetSource
+     */
+    public function __construct(PixxioAssetSource $assetSource)
+    {
+        $this->assetSource = $assetSource;
+    }
 
     /**
      * @param string $identifier

--- a/Classes/AssetSource/PixxioAssetProxyRepository.php
+++ b/Classes/AssetSource/PixxioAssetProxyRepository.php
@@ -21,24 +21,31 @@ use Flownative\Pixxio\Exception\ConnectionException;
 use Flownative\Pixxio\Exception\MissingClientSecretException;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
+use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Model\AssetSource\AssetNotFoundExceptionInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxyQueryResultInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxyRepositoryInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceConnectionExceptionInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetTypeFilter;
+use Neos\Media\Domain\Model\AssetSource\SupportsCollectionsInterface;
 use Neos\Media\Domain\Model\AssetSource\SupportsSortingInterface;
 use Neos\Media\Domain\Model\Tag;
 
 /**
  * PixxioAssetProxyRepository
  */
-class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, SupportsSortingInterface
+class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, SupportsSortingInterface, SupportsCollectionsInterface
 {
     /**
      * @var PixxioAssetSource
      */
     private $assetSource;
+
+    /**
+     * @var string|null
+     */
+    protected $assetCollectionFilter;
 
     /**
      * @var string
@@ -114,6 +121,11 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
         $this->assetTypeFilter = (string)$assetType ?: 'All';
     }
 
+    public function filterByCollection(AssetCollection $assetCollection = null): void
+    {
+        $this->assetCollectionFilter = $assetCollection ? $assetCollection->getTitle() : null;
+    }
+
     /**
      * @return AssetProxyQueryResultInterface
      */
@@ -121,6 +133,7 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
     {
         $query = new PixxioAssetProxyQuery($this->assetSource);
         $query->setAssetTypeFilter($this->assetTypeFilter);
+        $query->setAssetCollectionFilter($this->assetCollectionFilter);
         $query->setOrderings($this->orderings);
         return new PixxioAssetProxyQueryResult($query);
     }
@@ -134,6 +147,7 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
         $query = new PixxioAssetProxyQuery($this->assetSource);
         $query->setSearchTerm($searchTerm);
         $query->setAssetTypeFilter($this->assetTypeFilter);
+        $query->setAssetCollectionFilter($this->assetCollectionFilter);
         $query->setOrderings($this->orderings);
         return new PixxioAssetProxyQueryResult($query);
     }
@@ -147,6 +161,7 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
         $query = new PixxioAssetProxyQuery($this->assetSource);
         $query->setSearchTerm($tag->getLabel());
         $query->setAssetTypeFilter($this->assetTypeFilter);
+        $query->setAssetCollectionFilter($this->assetCollectionFilter);
         $query->setOrderings($this->orderings);
         return new PixxioAssetProxyQueryResult($query);
     }
@@ -158,6 +173,7 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
     {
         $query = new PixxioAssetProxyQuery($this->assetSource);
         $query->setAssetTypeFilter($this->assetTypeFilter);
+        $query->setAssetCollectionFilter($this->assetCollectionFilter);
         $query->setOrderings($this->orderings);
         return new PixxioAssetProxyQueryResult($query);
     }

--- a/Classes/Command/PixxioCommandController.php
+++ b/Classes/Command/PixxioCommandController.php
@@ -10,7 +10,6 @@ use Flownative\Pixxio\Exception\MissingClientSecretException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Media\Domain\Model\Asset;
-use Neos\Media\Domain\Model\AssetSource\AssetProxy\SupportsIptcMetadataInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceAwareInterface;
 use Neos\Media\Domain\Repository\AssetRepository;
 

--- a/Classes/Command/PixxioCommandController.php
+++ b/Classes/Command/PixxioCommandController.php
@@ -9,9 +9,15 @@ use Flownative\Pixxio\Exception\AuthenticationFailedException;
 use Flownative\Pixxio\Exception\MissingClientSecretException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
+use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Media\Domain\Model\Asset;
+use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Model\AssetSource\AssetSourceAwareInterface;
+use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Media\Domain\Repository\AssetRepository;
+use Neos\Media\Domain\Repository\TagRepository;
+use Neos\Media\Domain\Service\AssetSourceService;
 
 class PixxioCommandController extends CommandController
 {
@@ -20,6 +26,30 @@ class PixxioCommandController extends CommandController
      * @var AssetRepository
      */
     protected $assetRepository;
+
+    /**
+     * @Flow\Inject
+     * @var AssetSourceService
+     */
+    protected $assetSourceService;
+
+    /**
+     * @Flow\Inject
+     * @var TagRepository
+     */
+    protected $tagRepository;
+
+    /**
+     * @Flow\Inject
+     * @var AssetCollectionRepository
+     */
+    protected $assetCollectionRepository;
+
+    /**
+     * @Flow\InjectConfiguration(path="mapping", package="Flownative.Pixxio")
+     * @var array
+     */
+    protected $mapping = [];
 
     /**
      * @Flow\InjectConfiguration(path="assetSources", package="Neos.Media")
@@ -193,5 +223,81 @@ class PixxioCommandController extends CommandController
             !$quiet && $this->outputLine('💡 You may want to run ./flow flow:cache:flushone Neos_Fusion');
             !$quiet && $this->outputLine('   in order to make changes visible in the frontend');
         }
+    }
+
+    /**
+     * Import pixx.io categories as asset collections
+     *
+     * @param string $assetSourceIdentifier Name of the pixx.io asset source (defaults to "flownative-pixxio")
+     * @param bool $quiet If set, only errors will be displayed.
+     * @param bool $dryRun If set, no changes will be made.
+     * @return void
+     * @throws IllegalObjectTypeException
+     * @throws \Flownative\Pixxio\Exception\ConnectionException
+     */
+    public function importCategoriesAsCollectionsCommand(string $assetSourceIdentifier = 'flownative-pixxio', bool $quiet = true, bool $dryRun = false): void
+    {
+        !$quiet && $this->outputLine('<b>Importing categories as asset collections via pixx.io API</b>');
+
+        try {
+            $pixxioAssetSource = new PixxioAssetSource($assetSourceIdentifier, $this->assetSourcesConfiguration[$assetSourceIdentifier]['assetSourceOptions']);
+            $cantoClient = $pixxioAssetSource->getPixxioClient();
+        } catch (\Exception $e) {
+            $this->outputLine('<error>pixx.io client could not be created</error>');
+            $this->quit(1);
+        }
+
+        $response = $cantoClient->getCategories();
+        $responseObject = \GuzzleHttp\json_decode($response->getBody());
+        foreach ($responseObject->categories as $categoryPath) {
+            $categoryPath = ltrim($categoryPath, '/');
+            if ($this->shouldBeImportedAsAssetCollection($categoryPath)) {
+                $assetCollection = $this->assetCollectionRepository->findOneByTitle($categoryPath);
+
+                if (!($assetCollection instanceof AssetCollection)) {
+                    if (!$dryRun) {
+                        $assetCollection = new AssetCollection($categoryPath);
+                        $this->assetCollectionRepository->add($assetCollection);
+                    }
+                    !$quiet && $this->outputLine('+ %s', [$categoryPath]);
+                } else {
+                    !$quiet && $this->outputLine('= %s', [$categoryPath]);
+                }
+            } else {
+                !$quiet && $this->outputLine('o %s', [$categoryPath]);
+            }
+        }
+
+        !$quiet && $this->outputLine('<success>Import done.</success>');
+    }
+
+    public function shouldBeImportedAsAssetCollection(string $categoryPath): bool
+    {
+        $categoriesMapping = $this->mapping['categories'];
+        if (empty($categoriesMapping)) {
+            $this->outputLine('<error>No categories configured for mapping</error>');
+            $this->quit(1);
+        }
+
+        $categoryPath = ltrim($categoryPath, '/');
+
+        // depth limit
+        if (substr_count($categoryPath, '/') >= $this->mapping['categoriesMaximumDepth']) {
+            return false;
+        }
+
+        // full match
+        if (array_key_exists($categoryPath, $categoriesMapping)) {
+            return $categoriesMapping[$categoryPath]['asAssetCollection'];
+        }
+
+        // glob match
+        foreach ($categoriesMapping as $mappedCategory => $mapping) {
+            if (fnmatch($mappedCategory, $categoryPath)) {
+                return $mapping['asAssetCollection'];
+            }
+        }
+
+        return false;
     }
 }

--- a/Classes/Controller/PixxioController.php
+++ b/Classes/Controller/PixxioController.php
@@ -12,12 +12,12 @@ namespace Flownative\Pixxio\Controller;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
 use Flownative\Pixxio\AssetSource\PixxioAssetSource;
 use Flownative\Pixxio\Domain\Model\ClientSecret;
 use Flownative\Pixxio\Domain\Repository\ClientSecretRepository;
 use Flownative\Pixxio\Exception\AuthenticationFailedException;
 use Flownative\Pixxio\Exception\MissingClientSecretException;
-use Flownative\Pixxio\Service\PixxioServiceFactory;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
@@ -44,12 +44,6 @@ class PixxioController extends AbstractModuleController
      * @var ClientSecretRepository
      */
     protected $clientSecretRepository;
-
-    /**
-     * @Flow\Inject
-     * @var PixxioServiceFactory
-     */
-    protected $pixxioServiceFactory;
 
     /**
      * @return void

--- a/Classes/Service/PixxioClient.php
+++ b/Classes/Service/PixxioClient.php
@@ -191,13 +191,14 @@ final class PixxioClient
      * @param string $queryExpression
      * @param array $formatTypes
      * @param array $fileTypes
+     * @param string|null $assetCollectionFilter
      * @param int $offset
      * @param int $limit
      * @param array $orderings
      * @return ResponseInterface
      * @throws ConnectionException
      */
-    public function search(string $queryExpression, array $formatTypes, array $fileTypes, int $offset = 0, int $limit = 50, $orderings = []): ResponseInterface
+    public function search(string $queryExpression, array $formatTypes, array $fileTypes, string $assetCollectionFilter = null, int $offset = 0, int $limit = 50, $orderings = []): ResponseInterface
     {
         $options = new \stdClass();
         $options->pagination = $limit . '-' . (int)($offset / $limit + 1);
@@ -205,6 +206,10 @@ final class PixxioClient
         $options->fields = $this->fields;
         $options->formatType = $formatTypes;
         $options->fileType = implode(',', $fileTypes);
+
+        if ($assetCollectionFilter !== null) {
+            $options->category = 'sub/' . $assetCollectionFilter;
+        }
 
         if (!empty($queryExpression)) {
             $options->searchTerm = urlencode($queryExpression);
@@ -231,6 +236,25 @@ final class PixxioClient
             return $client->request('GET', $uri);
         } catch (GuzzleException $e) {
             throw new ConnectionException('Search failed: ' . $e->getMessage(), 1542808181);
+        }
+    }
+
+    /**
+     * @return ResponseInterface
+     * @throws ConnectionException
+     */
+    public function getCategories(): ResponseInterface
+    {
+        $uri = new Uri( $this->apiEndpointUri . '/json/categories');
+        $uri = $uri->withQuery(
+            'accessToken=' . $this->accessToken
+        );
+
+        $client = new Client($this->apiClientOptions);
+        try {
+            return $client->request('GET', $uri);
+        } catch (GuzzleException $e) {
+            throw new ConnectionException('Retrieving categories failed: ' . $e->getMessage(), 1642430939);
         }
     }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,3 +1,10 @@
+Flownative:
+  Pixxio:
+    mapping:
+      # map "categories" from pixx.io to Neos
+      categoriesMaximumDepth: 10
+      categories: []
+
 Neos:
   Flow:
     mvc:

--- a/README.md
+++ b/README.md
@@ -190,11 +190,20 @@ iterates over all assets which were imported from Pixxio and checks if tags need
 
 ### Category mapping from pixx.io to Neos
 
-Pixx.io offers categories to organize assets in a folder-like structure. Those
+pixx.io offers categories to organize assets in a folder-like structure. Those
 can be mapped to asset collections and tags in Neos, to make them visible for
 the  users.
 
-The configuration for this looks like that:
+.. note::
+   The pixx.io asset source declares itself read-only. Neos does not show asset
+   collections in the UI for read-only asset sources. This has been changed for
+   Neos 7.3.0 and up with https://github.com/neos/neos-development-collection/pull/3481
+
+   If you want to use this feature with older Neos versions, you can use the PR with
+   [cweagans/composer-patches](https://github.com/cweagans/composer-patches#readme)
+   or copy the adjusted template into your project and use `Views.yaml` to activate it.
+
+The configuration for the category import looks like this:
 
 ```yaml
 Flownative:
@@ -203,27 +212,28 @@ Flownative:
       # map "categories" from pixx.io to Neos
       categoriesMaximumDepth: 2         # only include the first two levels of categories
       categories:
+        'People/Employees':
+          asAssetCollection: false      # ignore this category, put more specific patterns first
         'People*':                      # the category "path" in pixx.io, shell-style globbing is supported
           asAssetCollection: true       # map to an asset collection named after the category
-        'People/Employees':
-          asAssetCollection: false      # ignore this category
 ```
 
-- The key used is the category identifier from pixx.io as used in the API
+- The key used is the category identifier from pixx.io as used in the API,
+  without leading slash
 - `asAssetCollection` set to `true` exposes the category as an asset
   collection named like the category.
 
 Afterwards, run the following command to update the asset collections, ideally
 in a cronjob to keep things up-to-date:
 
-```
+```bash
 ./flow pixxio:importcategoriesascollections
 ```
 
 To check what a given category would import, you can use a verbose dry-run:
 
-```
-beach@3bd503e8b61d:/application$ ./flow pixxio:importcategoriesascollections --quiet 0 --dry-run 1
+```bash
+$ ./flow pixxio:importcategoriesascollections --quiet 0 --dry-run 1
 Importing categories as asset collections via pixx.io API
 o Dokumentation
 = Kunde A

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # pixx.io adaptor for Neos
 
-This [Flow](https://flow.neos.io) package allows you to use assets (ie. pictures and other documents) stored in [pixx.io](https://www.pixxio-bildverwaltung.de/)
+This [Flow](https://flow.neos.io) package allows you to use assets (ie. pictures and other documents) stored in [pixx.io](https://www.pixx.io/)
 in your Neos website as if these assets were native Neos assets.
 
 ## About pixx.io
@@ -74,7 +74,7 @@ Neos:
 
 When you committed and deployed these changes, you can log in to the Neos backend and navigate to the pixx.io backend
 module to verify your settings.
-  
+
 If you would like a separate pixx.io user for the logged in Neos user, you can copy and paste your own "refresh token"
 into the form found in the backend module and store it along with your Neos user.
 
@@ -106,7 +106,7 @@ Neos:
 ```
 
 Sometimes the API Client needs additional configuration for the tls connection
-like custom timeouts or certificates. 
+like custom timeouts or certificates.
 See: http://docs.guzzlephp.org/en/6.5/request-options.html
 
 ```yaml
@@ -116,19 +116,19 @@ Neos:
       'flownative-pixxio':
         assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
         assetSourceOptions:
-          apiClientOptions: 
-            'verify': '/path/to/cert.pem'           
+          apiClientOptions:
+            'verify': '/path/to/cert.pem'
 ```
 
 ## Run database migrations
 ```bash
 ./flow doctrine:migrate
-``` 
+```
 
 ## Cleaning up unused assets
 
 Whenever a pixx.io asset is used in Neos, the media file will be copied automatically to the internal Neos asset
-storage. As long as this media is used somewhere on the website, Neos will flag this asset as being in use. 
+storage. As long as this media is used somewhere on the website, Neos will flag this asset as being in use.
 When an asset is not used anymore, the binary data and the corresponding metadata can be removed from the internal
 storage. While this does not happen automatically, it can be easily automated by a recurring task, such as a cron-job.
 
@@ -136,14 +136,14 @@ In order to clean up unused assets, simply run the following command as often as
 
 ```bash
 ./flow media:removeunused --asset-source flownative-pixxio
-``` 
+```
 
 If you'd rather like to invoke this command through a cron-job, you can add two additional flags which make this
 command non-interactive:
 
 ```bash
 ./flow media:removeunused --quiet --assume-yes --asset-source flownative-pixxio
-``` 
+```
 
 ## Auto-Tagging
 
@@ -167,8 +167,8 @@ Neos:
 ```
 
 Since Neos currently cannot handle auto-tagging reliably during runtime, the job must be done through a
-command line command. Simply run the following command for tagging new assets and removing tags from 
-assets which are not in use anymore: 
+command line command. Simply run the following command for tagging new assets and removing tags from
+assets which are not in use anymore:
 
 ```
 ./flow pixxio:tagusedassets
@@ -194,7 +194,7 @@ iterates over all assets which were imported from Pixxio and checks if tags need
 
 ## Credits and license
 
-This plugin was sponsored by [pixx.io](https://www.pixxio-bildverwaltung.de/) and its initial version was developed by
-Robert Lemke of [Flownative](https://www.flownative.com).
+The first version of this plugin was sponsored by [pixx.io](https://www.pixxio-bildverwaltung.de/) and its initial
+version was developed by Robert Lemke of [Flownative](https://www.flownative.com).
 
 See LICENSE for license details.

--- a/README.md
+++ b/README.md
@@ -179,8 +179,11 @@ It is recommended to run this command through a cron-job, ideally in combination
 command. It's important to run the `removeunused`-command *after* the tagging command, because otherwise removed
 images will not be untagged in the pixx.io media library.
 
-Note: At this point, the auto-tagging feature is not really optimized for performance. The command merely
+---
+**NOTE**  
+At this point, the auto-tagging feature is not really optimized for performance. The command merely
 iterates over all assets which were imported from pixx.io and checks if tags need to be updated.
+---
 
 ### Category mapping from pixx.io to Neos
 
@@ -188,14 +191,16 @@ pixx.io offers categories to organize assets in a folder-like structure. Those
 can be mapped to asset collections and tags in Neos, to make them visible for
 the  users.
 
-.. note::
-   The pixx.io asset source declares itself read-only. Neos does not show asset
-   collections in the UI for read-only asset sources. This has been changed for
-   Neos 7.3.0 and up with https://github.com/neos/neos-development-collection/pull/3481
+---
+**NOTE**  
+The pixx.io asset source declares itself read-only. Neos does not show asset
+collections in the UI for read-only asset sources. This has been changed for
+Neos 7.3.0 and up with https://github.com/neos/neos-development-collection/pull/3481
 
-   If you want to use this feature with older Neos versions, you can use the PR with
-   [cweagans/composer-patches](https://github.com/cweagans/composer-patches#readme)
-   or copy the adjusted template into your project and use `Views.yaml` to activate it.
+ If you want to use this feature with older Neos versions, you can use the PR with
+ [cweagans/composer-patches](https://github.com/cweagans/composer-patches#readme)
+ or copy the adjusted template into your project and use `Views.yaml` to activate it.
+---
 
 The configuration for the category import looks like this:
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,59 @@ images will not be untagged in the Pixxio media library.
 Note: At this point, the auto-tagging feature is not really optimized for performance. The command merely
 iterates over all assets which were imported from Pixxio and checks if tags need to be updated.
 
+### Category mapping from pixx.io to Neos
+
+Pixx.io offers categories to organize assets in a folder-like structure. Those
+can be mapped to asset collections and tags in Neos, to make them visible for
+the  users.
+
+The configuration for this looks like that:
+
+```yaml
+Flownative:
+  Pixxio:
+    mapping:
+      # map "categories" from pixx.io to Neos
+      categoriesMaximumDepth: 2         # only include the first two levels of categories
+      categories:
+        'People*':                      # the category "path" in pixx.io, shell-style globbing is supported
+          asAssetCollection: true       # map to an asset collection named after the category
+        'People/Employees':
+          asAssetCollection: false      # ignore this category
+```
+
+- The key used is the category identifier from pixx.io as used in the API
+- `asAssetCollection` set to `true` exposes the category as an asset
+  collection named like the category.
+
+Afterwards, run the following command to update the asset collections, ideally
+in a cronjob to keep things up-to-date:
+
+```
+./flow pixxio:importcategoriesascollections
+```
+
+To check what a given category would import, you can use a verbose dry-run:
+
+```
+beach@3bd503e8b61d:/application$ ./flow pixxio:importcategoriesascollections --quiet 0 --dry-run 1
+Importing categories as asset collections via pixx.io API
+o Dokumentation
+= Kunde A
+= Kunde A/Projekt 1
+o Kunde A/Projekt 1/Copy
+o Kunde A/Projekt 1/Design
++ Kunde A/Projekt 2
+o Kunde A/Projekt 2/Copy
+o Kunde A/Projekt 2/Design
+o Marketing
+o home
+o home/Doe_John
+Import done.
+```
+The above would have added "Kunde A/Projekt 2", the items marked "=" exist already,
+and everything else is ignored.
+
 ## Background and Demo
 
 [![Background and Demo](https://img.youtube.com/vi/nG05nn-Yd0I/0.jpg)](https://www.youtube.com/watch?v=nG05nn-Yd0I)

--- a/Tests/Unit/PixxioCommandControllerTest.php
+++ b/Tests/Unit/PixxioCommandControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Flownative\Pixxio\Tests\Unit;
+
+use Flownative\Pixxio\Command\PixxioCommandController;
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Aop;
+
+/**
+ * Testcase for the command controller
+ */
+class PixxioCommandControllerTest extends UnitTestCase
+{
+    protected static $mapping = [
+        'categoriesMaximumDepth' => 2,
+        'categories' => [
+            'home*' => ['asAssetCollection' => false],
+            'Kunde A*' => ['asAssetCollection' => false],
+            '*' => ['asAssetCollection' => true]
+        ],
+    ];
+
+    public function setUp(): void
+    {
+        $this->mockCommandController = $this->getAccessibleMock(PixxioCommandController::class, ['dummy']);
+        $this->mockCommandController->_set('mapping', self::$mapping);
+    }
+
+    public function categoriesMappingProvider(): array
+    {
+        return [
+            '/home' => ['/home', false],
+            '/home/foo' => ['/home/foo', false],
+            '/Kunde A' => ['/Kunde A', false],
+            '/Kunde A/Projekt 1' => ['/Kunde A/Projekt 1', false],
+            '/Kunde A/Projekt 1/Design' => ['/Kunde A/Projekt 1/Design', false],
+            '/Kunde A/Projekt 1/Copy' => ['/Kunde A/Projekt 1/Copy', false],
+            '/Kunde B' => ['/Kunde B', true],
+            '/Kunde B/Projekt 1' => ['/Kunde B/Projekt 1', true],
+            '/Kunde B/Projekt 1/Design' => ['/Kunde B/Projekt 1/Design', false],
+            '/Kunde B/Projekt 1/Copy' => ['/Kunde B/Projekt 1/Copy', false],
+            '/Kunde B/Projekt 2' => ['/Kunde B/Projekt 2', true],
+            '/Kunde B/Projekt 2/Copy' => ['/Kunde B/Projekt 2/Copy', false],
+            '/Kunde B/Projekt 2/Design' => ['/Kunde B/Projekt 2/Design', false],
+            '/Marketing' => ['/Marketing', true],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider categoriesMappingProvider
+     */
+    public function shouldBeImportedAsAssetCollectionWorks(string $category, bool $expected): void
+    {
+        self::assertSame($expected, $this->mockCommandController->_call('shouldBeImportedAsAssetCollection', $category), $category);
+    }
+}


### PR DESCRIPTION
This provides a way to filter on the pixx.io side by the selected asset collection.
This allows to provide the category (folder) structure in pixx.io on the Neos side.

To support this, a CLI command is added to import (a configurable set of)
categories into Neos as asset collections.