### PR TITLE
TASK: Ensure initialized account before creating client secret lookup

### DIFF
--- a/Classes/AssetSource/PixxioAssetSource.php
+++ b/Classes/AssetSource/PixxioAssetSource.php
@@ -269,7 +269,7 @@ class PixxioAssetSource implements AssetSourceInterface
     {
         if ($this->pixxioClient === null) {
 
-            if ($this->securityContext->isInitialized()) {
+            if ($this->securityContext->isInitialized() && $this->securityContext->getAccount()) {
                 $account = $this->securityContext->getAccount();
                 $clientSecret = $this->clientSecretRepository->findOneByFlowAccountIdentifier($account->getAccountIdentifier());
             } else {


### PR DESCRIPTION
In a combination with a custom ThumbnailGenerator from the `Sitegeist.AssetSource.3QVideo` package (https://github.com/sitegeist/Sitegeist.AssetSource.3QVideo/blob/main/Classes/Domain/ThumbnailGenerator.php) there is no Account in the security context, when going through the ThumbnailStrategies on a `media/thumbnail/<uuid>` url.

This change adds a check for a actual account, before trying to fetch a client secret

Resolves #16