### PR TITLE
Support for multiple tenants

### DIFF
--- a/Classes/AssetSource/PixxioAssetProxy.php
+++ b/Classes/AssetSource/PixxioAssetProxy.php
@@ -91,12 +91,12 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
     private $originalUri;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $widthInPixels;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $heightInPixels;
 
@@ -120,7 +120,7 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
     public static function fromJsonObject(stdClass $jsonObject, PixxioAssetSource $assetSource): PixxioAssetProxy
     {
         $assetSourceOptions = $assetSource->getAssetSourceOptions();
-        $pixxioOriginalMediaType = MediaTypes::getMediaTypeFromFilename('foo.' . strtolower($jsonObject->fileType));;
+        $pixxioOriginalMediaType = MediaTypes::getMediaTypeFromFilename('foo.' . strtolower($jsonObject->fileType));
         $usePixxioThumbnailAsOriginal = (!isset($assetSourceOptions['mediaTypes'][$pixxioOriginalMediaType]) || $assetSourceOptions['mediaTypes'][$pixxioOriginalMediaType]['usePixxioThumbnailAsOriginal'] === false);
         $modifiedFileType = $usePixxioThumbnailAsOriginal ? 'jpg' : strtolower($jsonObject->fileType);
 
@@ -270,7 +270,7 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
     }
 
     /**
-     * @return UriInterface
+     * @return UriInterface|null
      */
     public function getThumbnailUri(): ?UriInterface
     {
@@ -278,7 +278,7 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
     }
 
     /**
-     * @return UriInterface
+     * @return UriInterface|null
      */
     public function getPreviewUri(): ?UriInterface
     {
@@ -299,13 +299,13 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
             }
 
             return false;
-        } catch (GuzzleException $e) {
-            throw new ConnectionException('Retrieving file failed: ' . $e->getMessage(), 1542808207, $e);
+        } catch (GuzzleException $exception) {
+            throw new ConnectionException('Retrieving file failed: ' . $exception->getMessage(), 1542808207, $exception);
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLocalAssetIdentifier(): ?string
     {

--- a/Classes/AssetSource/PixxioAssetProxy.php
+++ b/Classes/AssetSource/PixxioAssetProxy.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\AssetSource;
 
@@ -35,75 +36,33 @@ use stdClass;
  */
 final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalInterface, SupportsIptcMetadataInterface
 {
-    /**
-     * @var PixxioAssetSource
-     */
-    private $assetSource;
+    private PixxioAssetSource $assetSource;
 
-    /**
-     * @var string
-     */
-    private $identifier;
+    private string $identifier;
 
-    /**
-     * @var string
-     */
-    private $label;
+    private string $label;
 
-    /**
-     * @var string
-     */
-    private $filename;
+    private string $filename;
 
-    /**
-     * @var \DateTime
-     */
-    private $lastModified;
+    private \DateTime $lastModified;
 
-    /**
-     * @var int
-     */
-    private $fileSize;
+    private int $fileSize;
 
-    /**
-     * @var string
-     */
-    private $mediaType;
+    private string $mediaType;
 
-    /**
-     * @var array
-     */
-    private $iptcProperties = [];
+    private array $iptcProperties = [];
 
-    /**
-     * @var UriInterface
-     */
-    private $thumbnailUri;
+    private UriInterface $thumbnailUri;
 
-    /**
-     * @var UriInterface
-     */
-    private $previewUri;
+    private UriInterface $previewUri;
 
-    /**
-     * @var UriInterface
-     */
-    private $originalUri;
+    private UriInterface $originalUri;
 
-    /**
-     * @var int|null
-     */
-    private $widthInPixels;
+    private ?int $widthInPixels;
 
-    /**
-     * @var int|null
-     */
-    private $heightInPixels;
+    private ?int $heightInPixels;
 
-    /**
-     * @var array
-     */
-    private $tags = [];
+    private array $tags = [];
 
     /**
      * @Flow\Inject
@@ -112,9 +71,6 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
     protected $importedAssetRepository;
 
     /**
-     * @param stdClass $jsonObject
-     * @param PixxioAssetSource $assetSource
-     * @return static
      * @throws Exception
      */
     public static function fromJsonObject(stdClass $jsonObject, PixxioAssetSource $assetSource): PixxioAssetProxy
@@ -130,7 +86,7 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
         $assetProxy->label = $jsonObject->subject;
         $assetProxy->filename = Transliterator::urlize($jsonObject->subject) . '.' . $modifiedFileType;
         $assetProxy->lastModified = new \DateTime($jsonObject->modifyDate ?? '1.1.2000');
-        $assetProxy->fileSize = $jsonObject->fileSize;
+        $assetProxy->fileSize = (int)$jsonObject->fileSize;
         $assetProxy->mediaType = MediaTypes::getMediaTypeFromFilename('foo.' . $modifiedFileType);
         $assetProxy->tags = isset($jsonObject->keywords) ? explode(',', $jsonObject->keywords) : [];
 
@@ -138,8 +94,8 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
         $assetProxy->iptcProperties['CaptionAbstract'] = $jsonObject->description ?? '';
         $assetProxy->iptcProperties['CopyrightNotice'] = $jsonObject->dynamicMetadata->CopyrightNotice ?? '';
 
-        $assetProxy->widthInPixels = $jsonObject->imageWidth ?? null;
-        $assetProxy->heightInPixels = $jsonObject->imageHeight ?? null;
+        $assetProxy->widthInPixels = $jsonObject->imageWidth ? (int)$jsonObject->imageWidth : null;
+        $assetProxy->heightInPixels = $jsonObject->imageHeight ? (int)$jsonObject->imageHeight : null;
 
         if (isset($jsonObject->modifiedImagePaths)) {
             $modifiedImagePaths = $jsonObject->modifiedImagePaths;
@@ -171,122 +127,77 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
         return $assetProxy;
     }
 
-    /**
-     * @return AssetSourceInterface
-     */
     public function getAssetSource(): AssetSourceInterface
     {
         return $this->assetSource;
     }
 
-    /**
-     * @return string
-     */
     public function getIdentifier(): string
     {
         return $this->identifier;
     }
 
-    /**
-     * @return string
-     */
     public function getLabel(): string
     {
         return $this->label;
     }
 
-    /**
-     * @return string
-     */
     public function getFilename(): string
     {
         return $this->filename;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
     public function getLastModified(): \DateTimeInterface
     {
         return $this->lastModified;
     }
 
-    /**
-     * @return int
-     */
     public function getFileSize(): int
     {
         return $this->fileSize;
     }
 
-    /**
-     * @return string
-     */
     public function getMediaType(): string
     {
         return $this->mediaType;
     }
 
-    /**
-     * @param string $propertyName
-     * @return bool
-     */
     public function hasIptcProperty(string $propertyName): bool
     {
         return isset($this->iptcProperties[$propertyName]);
     }
 
-    /**
-     * @param string $propertyName
-     * @return string
-     */
     public function getIptcProperty(string $propertyName): string
     {
         return $this->iptcProperties[$propertyName] ?? '';
     }
 
-    /**
-     * @return array
-     */
     public function getIptcProperties(): array
     {
         return $this->iptcProperties;
     }
 
-    /**
-     * @return int|null
-     */
     public function getWidthInPixels(): ?int
     {
         return $this->widthInPixels;
     }
 
-    /**
-     * @return int|null
-     */
     public function getHeightInPixels(): ?int
     {
         return $this->heightInPixels;
     }
 
-    /**
-     * @return UriInterface|null
-     */
     public function getThumbnailUri(): ?UriInterface
     {
         return $this->thumbnailUri;
     }
 
-    /**
-     * @return UriInterface|null
-     */
     public function getPreviewUri(): ?UriInterface
     {
         return $this->previewUri;
     }
 
     /**
-     * @return bool|resource
      * @throws ConnectionException
      */
     public function getImportStream()
@@ -304,26 +215,17 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
         }
     }
 
-    /**
-     * @return string|null
-     */
     public function getLocalAssetIdentifier(): ?string
     {
         $importedAsset = $this->importedAssetRepository->findOneByAssetSourceIdentifierAndRemoteAssetIdentifier($this->assetSource->getIdentifier(), $this->identifier);
         return ($importedAsset instanceof ImportedAsset ? $importedAsset->getLocalAssetIdentifier() : null);
     }
 
-    /**
-     * @return array
-     */
     public function getTags(): array
     {
         return $this->tags;
     }
 
-    /**
-     * @return bool
-     */
     public function isImported(): bool
     {
         return true;

--- a/Classes/AssetSource/PixxioAssetProxy.php
+++ b/Classes/AssetSource/PixxioAssetProxy.php
@@ -68,7 +68,7 @@ final class PixxioAssetProxy implements AssetProxyInterface, HasRemoteOriginalIn
      * @Flow\Inject
      * @var ImportedAssetRepository
      */
-    protected $importedAssetRepository;
+    protected ImportedAssetRepository $importedAssetRepository;
 
     /**
      * @throws Exception

--- a/Classes/AssetSource/PixxioAssetProxyQuery.php
+++ b/Classes/AssetSource/PixxioAssetProxyQuery.php
@@ -17,6 +17,7 @@ use Flownative\Pixxio\Exception\AuthenticationFailedException;
 use Flownative\Pixxio\Exception\ConnectionException;
 use Flownative\Pixxio\Exception\MissingClientSecretException;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Utils;
 use Neos\Flow\Annotations\Inject;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
@@ -216,7 +217,7 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
     {
         try {
             $response = $this->sendSearchRequest(1, []);
-            $responseObject = \GuzzleHttp\json_decode($response->getBody());
+            $responseObject = Utils::jsonDecode($response->getBody()->getContents());
 
             if (!isset($responseObject->quantity)) {
                 if (isset($responseObject->help)) {
@@ -225,7 +226,7 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
                 }
                 return 0;
             }
-            return $responseObject->quantity;
+            return (int)$responseObject->quantity;
         } catch (AuthenticationFailedException $exception) {
             $message = $this->throwableStorage->logThrowable(new ConnectionException('Connection to pixx.io failed.', 1526629541, $exception));
             $this->logger->error($message, LogEnvironment::fromMethodName(__METHOD__));
@@ -250,7 +251,7 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
         try {
             $assetProxies = [];
             $response = $this->sendSearchRequest($this->limit, $this->orderings);
-            $responseObject = \GuzzleHttp\json_decode($response->getBody());
+            $responseObject = Utils::jsonDecode($response->getBody()->getContents());
 
             if (!isset($responseObject->files)) {
                 return [];

--- a/Classes/AssetSource/PixxioAssetProxyQuery.php
+++ b/Classes/AssetSource/PixxioAssetProxyQuery.php
@@ -49,15 +49,13 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
 
     /**
      * @Inject
-     * @var LoggerInterface
      */
     protected LoggerInterface $logger;
 
     /**
      * @Inject
-     * @var ThrowableStorageInterface
      */
-    protected $throwableStorage;
+    protected ThrowableStorageInterface $throwableStorage;
 
     public function __construct(PixxioAssetSource $assetSource)
     {

--- a/Classes/AssetSource/PixxioAssetProxyQuery.php
+++ b/Classes/AssetSource/PixxioAssetProxyQuery.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\AssetSource;
 
@@ -30,51 +31,27 @@ use Psr\Log\LoggerInterface;
  */
 final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
 {
-    /**
-     * @var PixxioAssetSource
-     */
-    private $assetSource;
+    private PixxioAssetSource $assetSource;
 
-    /**
-     * @var string
-     */
-    private $searchTerm = '';
+    private string $searchTerm = '';
 
-    /**
-     * @var string
-     */
-    private $assetTypeFilter = 'All';
+    private string $assetTypeFilter = 'All';
 
-    /**
-     * @var ?string
-     */
-    private $assetCollectionFilter;
+    private ?string $assetCollectionFilter;
 
-    /**
-     * @var array
-     */
-    private $orderings = [];
+    private array $orderings = [];
 
-    /**
-     * @var int
-     */
-    private $offset = 0;
+    private int $offset = 0;
 
-    /**
-     * @var int
-     */
-    private $limit = 30;
+    private int $limit = 30;
 
-    /**
-     * @var string
-     */
-    private $parentFolderIdentifier = '';
+    private string $parentFolderIdentifier = '';
 
     /**
      * @Inject
      * @var LoggerInterface
      */
-    protected $logger;
+    protected LoggerInterface $logger;
 
     /**
      * @Inject
@@ -82,137 +59,86 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
      */
     protected $throwableStorage;
 
-    /**
-     * @param PixxioAssetSource $assetSource
-     */
     public function __construct(PixxioAssetSource $assetSource)
     {
         $this->assetSource = $assetSource;
     }
 
-    /**
-     * @param int $offset
-     */
     public function setOffset(int $offset): void
     {
         $this->offset = $offset;
     }
 
-    /**
-     * @return int
-     */
     public function getOffset(): int
     {
         return $this->offset;
     }
 
-    /**
-     * @param int $limit
-     */
     public function setLimit(int $limit): void
     {
         $this->limit = $limit;
     }
 
-    /**
-     * @return int
-     */
     public function getLimit(): int
     {
         return $this->limit;
     }
 
-    /**
-     * @param string $searchTerm
-     */
     public function setSearchTerm(string $searchTerm): void
     {
         $this->searchTerm = $searchTerm;
     }
 
-    /**
-     * @return string
-     */
     public function getSearchTerm(): string
     {
         return $this->searchTerm;
     }
 
-    /**
-     * @param string $assetTypeFilter
-     */
     public function setAssetTypeFilter(string $assetTypeFilter): void
     {
         $this->assetTypeFilter = $assetTypeFilter;
     }
 
-    /**
-     * @return string
-     */
     public function getAssetTypeFilter(): string
     {
         return $this->assetTypeFilter;
     }
 
-    /**
-     * @param ?string $assetCollectionFilter
-     */
     public function setAssetCollectionFilter(?string $assetCollectionFilter): void
     {
         $this->assetCollectionFilter = $assetCollectionFilter;
     }
 
-    /**
-     * @return ?string
-     */
     public function getAssetCollectionFilter(): ?string
     {
         return $this->assetCollectionFilter;
     }
 
-    /**
-     * @return array
-     */
     public function getOrderings(): array
     {
         return $this->orderings;
     }
 
-    /**
-     * @param array $orderings
-     */
     public function setOrderings(array $orderings): void
     {
         $this->orderings = $orderings;
     }
 
-    /**
-     * @return string
-     */
     public function getParentFolderIdentifier(): string
     {
         return $this->parentFolderIdentifier;
     }
 
-    /**
-     * @param string $parentFolderIdentifier
-     */
     public function setParentFolderIdentifier(string $parentFolderIdentifier): void
     {
         $this->parentFolderIdentifier = $parentFolderIdentifier;
     }
 
-    /**
-     * @return AssetProxyQueryResultInterface
-     */
     public function execute(): AssetProxyQueryResultInterface
     {
         return new PixxioAssetProxyQueryResult($this);
     }
 
-    /**
-     * @return int
-     */
     public function count(): int
     {
         try {
@@ -272,9 +198,6 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
     }
 
     /**
-     * @param int $limit
-     * @param array $orderings
-     * @return Response
      * @throws AuthenticationFailedException
      * @throws MissingClientSecretException
      * @throws ConnectionException

--- a/Classes/AssetSource/PixxioAssetProxyQueryResult.php
+++ b/Classes/AssetSource/PixxioAssetProxyQueryResult.php
@@ -14,7 +14,6 @@ namespace Flownative\Pixxio\AssetSource;
  * source code.
  */
 
-use Flownative\Pixxio\Exception\ConnectionException;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxyQueryInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxyQueryResultInterface;

--- a/Classes/AssetSource/PixxioAssetProxyQueryResult.php
+++ b/Classes/AssetSource/PixxioAssetProxyQueryResult.php
@@ -13,6 +13,7 @@ namespace Flownative\Pixxio\AssetSource;
  * source code.
  */
 
+use Flownative\Pixxio\Exception\ConnectionException;
 use Neos\Media\Domain\Model\AssetSource\AssetProxy\AssetProxyInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxyQueryInterface;
 use Neos\Media\Domain\Model\AssetSource\AssetProxyQueryResultInterface;
@@ -141,7 +142,7 @@ class PixxioAssetProxyQueryResult implements AssetProxyQueryResultInterface
 
     /**
      * @return int
-     * @throws \Flownative\Pixxio\Exception\ConnectionException
+     * @throws ConnectionException
      */
     public function count(): int
     {

--- a/Classes/AssetSource/PixxioAssetProxyQueryResult.php
+++ b/Classes/AssetSource/PixxioAssetProxyQueryResult.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\AssetSource;
 
@@ -23,37 +24,19 @@ use Neos\Media\Domain\Model\AssetSource\AssetProxyQueryResultInterface;
  */
 class PixxioAssetProxyQueryResult implements AssetProxyQueryResultInterface
 {
-    /**
-     * @var PixxioAssetProxyQuery
-     */
-    private $query;
+    private PixxioAssetProxyQuery $query;
 
-    /**
-     * @var array
-     */
-    private $assetProxies;
+    private ?array $assetProxies = null;
 
-    /**
-     * @var int
-     */
-    private $numberOfAssetProxies;
+    private ?int $numberOfAssetProxies = null;
 
-    /**
-     * @var \ArrayIterator
-     */
-    private $assetProxiesIterator;
+    private \ArrayIterator $assetProxiesIterator;
 
-    /**
-     * @param PixxioAssetProxyQuery $query
-     */
     public function __construct(PixxioAssetProxyQuery $query)
     {
         $this->query = $query;
     }
 
-    /**
-     * @return void
-     */
     private function initialize(): void
     {
         if ($this->assetProxies === null) {
@@ -62,17 +45,11 @@ class PixxioAssetProxyQueryResult implements AssetProxyQueryResultInterface
         }
     }
 
-    /**
-     * @return AssetProxyQueryInterface
-     */
     public function getQuery(): AssetProxyQueryInterface
     {
         return clone $this->query;
     }
 
-    /**
-     * @return AssetProxyInterface|null
-     */
     public function getFirst(): ?AssetProxyInterface
     {
         $this->initialize();
@@ -94,7 +71,7 @@ class PixxioAssetProxyQueryResult implements AssetProxyQueryResultInterface
         return $this->assetProxiesIterator->current();
     }
 
-    public function next()
+    public function next(): void
     {
         $this->initialize();
         $this->assetProxiesIterator->next();
@@ -106,19 +83,19 @@ class PixxioAssetProxyQueryResult implements AssetProxyQueryResultInterface
         return $this->assetProxiesIterator->key();
     }
 
-    public function valid()
+    public function valid(): bool
     {
         $this->initialize();
         return $this->assetProxiesIterator->valid();
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->initialize();
         $this->assetProxiesIterator->rewind();
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $this->initialize();
         return $this->assetProxiesIterator->offsetExists($offset);
@@ -130,7 +107,7 @@ class PixxioAssetProxyQueryResult implements AssetProxyQueryResultInterface
         return $this->assetProxiesIterator->offsetGet($offset);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->initialize();
         $this->assetProxiesIterator->offsetSet($offset, $value);
@@ -140,10 +117,6 @@ class PixxioAssetProxyQueryResult implements AssetProxyQueryResultInterface
     {
     }
 
-    /**
-     * @return int
-     * @throws ConnectionException
-     */
     public function count(): int
     {
         if ($this->numberOfAssetProxies === null) {

--- a/Classes/AssetSource/PixxioAssetProxyRepository.php
+++ b/Classes/AssetSource/PixxioAssetProxyRepository.php
@@ -80,12 +80,10 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
                 throw new AssetNotFoundException('Asset not found', 1526636260);
             }
             if (!isset($responseObject->success) || $responseObject->success !== 'true') {
-                switch ($responseObject->status) {
-                    case 403:
-                        throw new AccessToAssetDeniedException(sprintf('Failed retrieving asset: %s', $response->help ?? '-') , 1589815740);
-                    default:
-                        throw new AssetNotFoundException(sprintf('Failed retrieving asset, unexpected API response: %s', $response->help ?? '-') , 1589354288);
-                }
+                throw match ($responseObject->status) {
+                    403 => new AccessToAssetDeniedException(sprintf('Failed retrieving asset: %s', $response->help ?? '-'), 1589815740),
+                    default => new AssetNotFoundException(sprintf('Failed retrieving asset, unexpected API response: %s', $response->help ?? '-'), 1589354288),
+                };
             }
 
             $this->assetProxyCache->set($cacheEntryIdentifier, Utils::jsonEncode($responseObject, JSON_FORCE_OBJECT));

--- a/Classes/AssetSource/PixxioAssetProxyRepository.php
+++ b/Classes/AssetSource/PixxioAssetProxyRepository.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\AssetSource;
 
@@ -13,13 +14,13 @@ namespace Flownative\Pixxio\AssetSource;
  * source code.
  */
 
-use Exception;
 use Flownative\Pixxio\Exception\AccessToAssetDeniedException;
 use Flownative\Pixxio\Exception\AssetNotFoundException;
 use Flownative\Pixxio\Exception\AuthenticationFailedException;
 use Flownative\Pixxio\Exception\ConnectionException;
 use Flownative\Pixxio\Exception\MissingClientSecretException;
 use GuzzleHttp\Utils;
+use Neos\Cache\Exception as CacheException;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Media\Domain\Model\AssetCollection;
@@ -38,50 +39,29 @@ use Neos\Media\Domain\Model\Tag;
  */
 class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, SupportsSortingInterface, SupportsCollectionsInterface
 {
-    /**
-     * @var PixxioAssetSource
-     */
-    private $assetSource;
+    private PixxioAssetSource $assetSource;
 
-    /**
-     * @var string|null
-     */
-    protected $assetCollectionFilter;
+    protected ?string $assetCollectionFilter;
 
-    /**
-     * @var string
-     */
-    private $assetTypeFilter = 'All';
+    private string $assetTypeFilter = 'All';
 
-    /**
-     * @var array
-     */
-    private $orderings = [];
+    private array $orderings = [];
 
-    /**
-     * @var StringFrontend
-     */
-    protected $assetProxyCache;
+    protected null|StringFrontend|DependencyProxy $assetProxyCache = null;
 
-    /**
-     * @param PixxioAssetSource $assetSource
-     */
     public function __construct(PixxioAssetSource $assetSource)
     {
         $this->assetSource = $assetSource;
     }
 
     /**
-     * @param string $identifier
-     * @return AssetProxyInterface
      * @throws AssetNotFoundExceptionInterface
      * @throws AssetSourceConnectionExceptionInterface
      * @throws MissingClientSecretException
      * @throws AuthenticationFailedException
      * @throws AssetNotFoundException
      * @throws ConnectionException
-     * @throws \Neos\Cache\Exception
-     * @throws Exception
+     * @throws CacheException
      */
     public function getAssetProxy(string $identifier): AssetProxyInterface
     {
@@ -113,9 +93,6 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
         return PixxioAssetProxy::fromJsonObject($responseObject, $this->assetSource);
     }
 
-    /**
-     * @param AssetTypeFilter|null $assetType
-     */
     public function filterByType(AssetTypeFilter $assetType = null): void
     {
         $this->assetTypeFilter = (string)$assetType ?: 'All';
@@ -126,9 +103,6 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
         $this->assetCollectionFilter = $assetCollection?->getTitle();
     }
 
-    /**
-     * @return AssetProxyQueryResultInterface
-     */
     public function findAll(): AssetProxyQueryResultInterface
     {
         $query = new PixxioAssetProxyQuery($this->assetSource);
@@ -138,10 +112,6 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
         return new PixxioAssetProxyQueryResult($query);
     }
 
-    /**
-     * @param string $searchTerm
-     * @return AssetProxyQueryResultInterface
-     */
     public function findBySearchTerm(string $searchTerm): AssetProxyQueryResultInterface
     {
         $query = new PixxioAssetProxyQuery($this->assetSource);
@@ -152,10 +122,6 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
         return new PixxioAssetProxyQueryResult($query);
     }
 
-    /**
-     * @param Tag $tag
-     * @return AssetProxyQueryResultInterface
-     */
     public function findByTag(Tag $tag): AssetProxyQueryResultInterface
     {
         $query = new PixxioAssetProxyQuery($this->assetSource);
@@ -166,9 +132,6 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
         return new PixxioAssetProxyQueryResult($query);
     }
 
-    /**
-     * @return AssetProxyQueryResultInterface
-     */
     public function findUntagged(): AssetProxyQueryResultInterface
     {
         $query = new PixxioAssetProxyQuery($this->assetSource);
@@ -178,33 +141,16 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
         return new PixxioAssetProxyQueryResult($query);
     }
 
-    /**
-     * @return int
-     */
     public function countAll(): int
     {
         return (new PixxioAssetProxyQuery($this->assetSource))->count();
     }
 
-    /**
-     * Sets the property names to order results by. Expected like this:
-     * array(
-     *  'filename' => SupportsSorting::ORDER_ASCENDING,
-     *  'lastModified' => SupportsSorting::ORDER_DESCENDING
-     * )
-     *
-     * @param array $orderings The property names to order by by default
-     * @return void
-     * @api
-     */
     public function orderBy(array $orderings): void
     {
         $this->orderings = $orderings;
     }
 
-    /**
-     * @return StringFrontend
-     */
     public function getAssetProxyCache(): StringFrontend
     {
         if ($this->assetProxyCache instanceof DependencyProxy) {

--- a/Classes/AssetSource/PixxioAssetSource.php
+++ b/Classes/AssetSource/PixxioAssetSource.php
@@ -77,11 +77,14 @@ class PixxioAssetSource implements AssetSourceInterface
 
     private array $assetSourceOptions;
 
-    protected string $iconPath;
+    protected string $iconPath = 'resource://Flownative.Pixxio/Public/Icons/PixxioWhite.svg';
 
-    protected string $description;
+    protected string $label = 'pixx.io';
+
+    protected string $description = '';
 
     /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(string $assetSourceIdentifier, array $assetSourceOptions)
     {
@@ -152,6 +155,9 @@ class PixxioAssetSource implements AssetSourceInterface
                 case 'icon':
                     $this->iconPath = $optionValue;
                     break;
+                case 'label':
+                    $this->label = $optionValue;
+                    break;
                 case 'description':
                     $this->description = $optionValue;
                     break;
@@ -173,7 +179,7 @@ class PixxioAssetSource implements AssetSourceInterface
 
     public function getLabel(): string
     {
-        return 'pixx.io';
+        return $this->label;
     }
 
     public function getAssetProxyRepository(): AssetProxyRepositoryInterface
@@ -215,7 +221,7 @@ class PixxioAssetSource implements AssetSourceInterface
 
             if ($this->securityContext->isInitialized() && $this->securityContext->getAccount()) {
                 $account = $this->securityContext->getAccount();
-                $clientSecret = $this->clientSecretRepository->findOneByFlowAccountIdentifier($account->getAccountIdentifier());
+                $clientSecret = $this->clientSecretRepository->findOneByIdentifiers($this->assetSourceIdentifier, $account->getAccountIdentifier());
             } else {
                 $clientSecret = null;
                 $account = new Account();
@@ -225,6 +231,7 @@ class PixxioAssetSource implements AssetSourceInterface
             if (!empty($this->sharedRefreshToken) && ($clientSecret === null || $clientSecret->getRefreshToken() === '')) {
                 $clientSecret = new ClientSecret();
                 $clientSecret->setRefreshToken($this->sharedRefreshToken);
+                $clientSecret->setAssetSourceIdentifier($this->assetSourceIdentifier);
                 $clientSecret->setFlowAccountIdentifier('shared');
             }
 

--- a/Classes/AssetSource/PixxioAssetSource.php
+++ b/Classes/AssetSource/PixxioAssetSource.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\AssetSource;
 
@@ -31,97 +32,56 @@ use Neos\Utility\MediaTypes;
 class PixxioAssetSource implements AssetSourceInterface
 {
     /**
-     * @var string
-     */
-    private $assetSourceIdentifier;
-
-    /**
-     * @var PixxioAssetProxyRepository
-     */
-    private $assetProxyRepository;
-
-    /**
      * @Flow\Inject
      * @var PixxioServiceFactory
      */
-    protected $pixxioServiceFactory;
+    protected PixxioServiceFactory $pixxioServiceFactory;
 
     /**
      * @Flow\Inject
      * @var ClientSecretRepository
      */
-    protected $clientSecretRepository;
+    protected ClientSecretRepository $clientSecretRepository;
 
     /**
      * @Flow\Inject
      * @var Context
      */
-    protected $securityContext;
+    protected Context $securityContext;
 
     /**
      * @Flow\Inject
      * @var ResourceManager
      */
-    protected $resourceManager;
+    protected ResourceManager $resourceManager;
+
+    private string $assetSourceIdentifier;
+
+    private ?PixxioAssetProxyRepository $assetProxyRepository = null;
+
+    private string $apiEndpointUri;
+
+    private string $apiKey;
+
+    private array $apiClientOptions = [];
+
+    private array $imageOptions = [];
+
+    private string $sharedRefreshToken;
+
+    private ?PixxioClient $pixxioClient = null;
+
+    private bool $autoTaggingEnable = false;
+
+    private string $autoTaggingInUseTag = 'used-by-neos';
+
+    private array $assetSourceOptions;
+
+    protected string $iconPath;
+
+    protected string $description;
 
     /**
-     * @var string
-     */
-    private $apiEndpointUri;
-
-    /**
-     * @var string
-     */
-    private $apiKey;
-
-    /**
-     * @var array
-     */
-    private $apiClientOptions = [];
-
-    /**
-     * @var array
-     */
-    private $imageOptions = [];
-
-    /**
-     * @var string
-     */
-    private $sharedRefreshToken;
-
-    /**
-     * @var PixxioClient
-     */
-    private $pixxioClient;
-
-    /**
-     * @var bool
-     */
-    private $autoTaggingEnable = false;
-
-    /**
-     * @var string
-     */
-    private $autoTaggingInUseTag = 'used-by-neos';
-
-    /**
-     * @var array
-     */
-    private $assetSourceOptions;
-
-    /**
-     * @var string
-     */
-    protected $iconPath;
-
-    /**
-     * @var string
-     */
-    protected $description = '';
-
-    /**
-     * @param string $assetSourceIdentifier
-     * @param array $assetSourceOptions
      */
     public function __construct(string $assetSourceIdentifier, array $assetSourceOptions)
     {
@@ -201,35 +161,21 @@ class PixxioAssetSource implements AssetSourceInterface
         }
     }
 
-    /**
-     * @param string $assetSourceIdentifier
-     * @param array $assetSourceOptions
-     * @return AssetSourceInterface
-     */
     public static function createFromConfiguration(string $assetSourceIdentifier, array $assetSourceOptions): AssetSourceInterface
     {
         return new static($assetSourceIdentifier, $assetSourceOptions);
     }
 
-    /**
-     * @return string
-     */
     public function getIdentifier(): string
     {
         return $this->assetSourceIdentifier;
     }
 
-    /**
-     * @return string
-     */
     public function getLabel(): string
     {
         return 'pixx.io';
     }
 
-    /**
-     * @return AssetProxyRepositoryInterface
-     */
     public function getAssetProxyRepository(): AssetProxyRepositoryInterface
     {
         if ($this->assetProxyRepository === null) {
@@ -239,40 +185,27 @@ class PixxioAssetSource implements AssetSourceInterface
         return $this->assetProxyRepository;
     }
 
-    /**
-     * @return bool
-     */
     public function isReadOnly(): bool
     {
         return true;
     }
 
-    /**
-     * @return array
-     */
     public function getAssetSourceOptions(): array
     {
         return $this->assetSourceOptions;
     }
 
-    /**
-     * @return bool
-     */
     public function isAutoTaggingEnabled(): bool
     {
         return $this->autoTaggingEnable;
     }
 
-    /**
-     * @return string
-     */
     public function getAutoTaggingInUseTag(): string
     {
         return $this->autoTaggingInUseTag;
     }
 
     /**
-     * @return PixxioClient
      * @throws MissingClientSecretException
      * @throws AuthenticationFailedException
      */
@@ -320,6 +253,4 @@ class PixxioAssetSource implements AssetSourceInterface
     {
         return $this->description;
     }
-
-
 }

--- a/Classes/AssetSource/PixxioAssetSource.php
+++ b/Classes/AssetSource/PixxioAssetSource.php
@@ -300,7 +300,6 @@ class PixxioAssetSource implements AssetSourceInterface
             }
 
             $this->pixxioClient = $this->pixxioServiceFactory->createForAccount(
-                $account->getAccountIdentifier(),
                 $this->apiEndpointUri,
                 $this->apiKey,
                 $this->apiClientOptions,

--- a/Classes/AssetSource/PixxioAssetSource.php
+++ b/Classes/AssetSource/PixxioAssetSource.php
@@ -34,25 +34,21 @@ class PixxioAssetSource implements AssetSourceInterface
 {
     /**
      * @Flow\Inject
-     * @var PixxioServiceFactory
      */
     protected PixxioServiceFactory $pixxioServiceFactory;
 
     /**
      * @Flow\Inject
-     * @var ClientSecretRepository
      */
     protected ClientSecretRepository $clientSecretRepository;
 
     /**
      * @Flow\Inject
-     * @var Context
      */
     protected Context $securityContext;
 
     /**
      * @Flow\Inject
-     * @var ResourceManager
      */
     protected ResourceManager $resourceManager;
 

--- a/Classes/Command/PixxioCommandController.php
+++ b/Classes/Command/PixxioCommandController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Flownative\Pixxio\Command;
 
 use Flownative\Pixxio\AssetSource\PixxioAssetProxy;
@@ -48,15 +50,13 @@ class PixxioCommandController extends CommandController
 
     /**
      * @Flow\InjectConfiguration(path="mapping", package="Flownative.Pixxio")
-     * @var array
      */
-    protected $mapping = [];
+    protected array $mapping = [];
 
     /**
      * @Flow\InjectConfiguration(path="assetSources", package="Neos.Media")
-     * @var array
      */
-    protected $assetSourcesConfiguration;
+    protected array $assetSourcesConfiguration = [];
 
     /**
      * Tag used assets
@@ -64,7 +64,6 @@ class PixxioCommandController extends CommandController
      * @param string $assetSource Name of the pixxio asset source
      * @param bool $quiet If set, only errors will be displayed.
      * @return void
-     * @throws
      */
     public function tagUsedAssetsCommand(string $assetSource = 'flownative-pixxio', bool $quiet = false): void
     {

--- a/Classes/Command/PixxioCommandController.php
+++ b/Classes/Command/PixxioCommandController.php
@@ -61,7 +61,7 @@ class PixxioCommandController extends CommandController
     /**
      * Tag used assets
      *
-     * @param string $assetSource Name of the pixxio asset source
+     * @param string $assetSource Name of the pixx.io asset source
      * @param bool $quiet If set, only errors will be displayed.
      * @return void
      */

--- a/Classes/Command/PixxioCommandController.php
+++ b/Classes/Command/PixxioCommandController.php
@@ -59,6 +59,30 @@ class PixxioCommandController extends CommandController
     protected array $assetSourcesConfiguration = [];
 
     /**
+     * List all configured (pixx.io) asset sources
+     *
+     * @param bool $showAll If true, all types of asset sources will be shown
+     * @return void
+     */
+    public function listCommand(bool $showAll = false): void
+    {
+        $assetSourcesData = [];
+
+        foreach ($this->assetSourceService->getAssetSources() as $assetSource) {
+            if ($showAll || $assetSource instanceof PixxioAssetSource) {
+                $assetSourcesData[] = [
+                    $assetSource->getIdentifier(),
+                    $assetSource->getLabel(),
+                    get_class($assetSource),
+                    $assetSource->getDescription()
+                ];
+            }
+        }
+
+        $this->output->outputTable($assetSourcesData, ['Identifier', 'Label', 'Type', 'Description']);
+    }
+
+    /**
      * Tag used assets
      *
      * @param string $assetSource Name of the pixx.io asset source

--- a/Classes/Controller/PixxioController.php
+++ b/Classes/Controller/PixxioController.php
@@ -31,7 +31,7 @@ class PixxioController extends AbstractModuleController
      * @Flow\Inject
      * @var Context
      */
-    protected $securityContext;
+    protected Context $securityContext;
 
     /**
      * @Flow\InjectConfiguration(path="assetSources", package="Neos.Media")
@@ -42,7 +42,7 @@ class PixxioController extends AbstractModuleController
      * @Flow\Inject
      * @var ClientSecretRepository
      */
-    protected $clientSecretRepository;
+    protected ClientSecretRepository $clientSecretRepository;
 
     public function indexAction(): void
     {
@@ -64,6 +64,7 @@ class PixxioController extends AbstractModuleController
                 $assetSourceData['refreshToken'] = $clientSecret->getRefreshToken();
             }
             try {
+                /** @var PixxioAssetSource $assetSource */
                 $assetSource = PixxioAssetSource::createFromConfiguration($assetSourceIdentifier, $this->assetSourcesConfiguration[$assetSourceIdentifier]['assetSourceOptions']);
                 $assetSource->getPixxioClient();
                 $assetSourceData['connectionSucceeded'] = true;

--- a/Classes/Controller/PixxioController.php
+++ b/Classes/Controller/PixxioController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Controller;
 
@@ -34,9 +35,8 @@ class PixxioController extends AbstractModuleController
 
     /**
      * @Flow\InjectConfiguration(path="assetSources", package="Neos.Media")
-     * @var array
      */
-    protected $assetSourcesConfiguration;
+    protected array $assetSourcesConfiguration = [];
 
     /**
      * @Flow\Inject
@@ -44,10 +44,7 @@ class PixxioController extends AbstractModuleController
      */
     protected $clientSecretRepository;
 
-    /**
-     * @return void
-     */
-    public function indexAction()
+    public function indexAction(): void
     {
         $this->view->assign('apiEndpointUri', $this->assetSourcesConfiguration['flownative-pixxio']['assetSourceOptions']['apiEndpointUri']);
         $this->view->assign('sharedRefreshToken', $this->assetSourcesConfiguration['flownative-pixxio']['assetSourceOptions']['sharedRefreshToken'] ?? null);
@@ -69,11 +66,10 @@ class PixxioController extends AbstractModuleController
     }
 
     /**
-     * @param ?string|null $refreshToken
      * @throws IllegalObjectTypeException
      * @throws UnsupportedRequestTypeException
      */
-    public function updateRefreshTokenAction(string $refreshToken = null)
+    public function updateRefreshTokenAction(string $refreshToken = null): void
     {
         $account = $this->securityContext->getAccount();
         $clientSecret = $this->clientSecretRepository->findOneByFlowAccountIdentifier($account->getAccountIdentifier());

--- a/Classes/Controller/PixxioController.php
+++ b/Classes/Controller/PixxioController.php
@@ -64,7 +64,7 @@ class PixxioController extends AbstractModuleController
                 $assetSourceData['refreshToken'] = $clientSecret->getRefreshToken();
             }
             try {
-                $assetSource = new PixxioAssetSource($assetSourceIdentifier, $assetSourceConfiguration['assetSourceOptions']);
+                $assetSource = PixxioAssetSource::createFromConfiguration($assetSourceIdentifier, $this->assetSourcesConfiguration[$assetSourceIdentifier]['assetSourceOptions']);
                 $assetSource->getPixxioClient();
                 $assetSourceData['connectionSucceeded'] = true;
             } catch (MissingClientSecretException|AuthenticationFailedException $exception) {

--- a/Classes/Controller/PixxioController.php
+++ b/Classes/Controller/PixxioController.php
@@ -19,7 +19,6 @@ use Flownative\Pixxio\Domain\Repository\ClientSecretRepository;
 use Flownative\Pixxio\Exception\AuthenticationFailedException;
 use Flownative\Pixxio\Exception\MissingClientSecretException;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Security\Context;
@@ -70,10 +69,9 @@ class PixxioController extends AbstractModuleController
     }
 
     /**
-     * @param string $refreshToken
-     * @throws StopActionException
-     * @throws UnsupportedRequestTypeException
+     * @param ?string|null $refreshToken
      * @throws IllegalObjectTypeException
+     * @throws UnsupportedRequestTypeException
      */
     public function updateRefreshTokenAction(string $refreshToken = null)
     {

--- a/Classes/Domain/Model/ClientSecret.php
+++ b/Classes/Domain/Model/ClientSecret.php
@@ -36,7 +36,7 @@ class ClientSecret
 
     /**
      * @ORM\Column(nullable=true, type="text")
-     * @var string
+     * @var string|null
      */
     protected $accessToken;
 
@@ -73,7 +73,7 @@ class ClientSecret
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAccessToken(): ?string
     {

--- a/Classes/Domain/Model/ClientSecret.php
+++ b/Classes/Domain/Model/ClientSecret.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Domain\Model;
 
@@ -26,64 +27,46 @@ class ClientSecret
      * @Identity()
      * @var string
      */
-    protected $flowAccountIdentifier;
+    protected string $flowAccountIdentifier;
 
     /**
      * @ORM\Column(type="text")
      * @var string
      */
-    protected $refreshToken;
+    protected string $refreshToken;
 
     /**
      * @ORM\Column(nullable=true, type="text")
      * @var string|null
      */
-    protected $accessToken;
+    protected ?string $accessToken;
 
-    /**
-     * @return string
-     */
     public function getFlowAccountIdentifier(): string
     {
         return $this->flowAccountIdentifier;
     }
 
-    /**
-     * @param string $flowAccountIdentifier
-     */
     public function setFlowAccountIdentifier(string $flowAccountIdentifier): void
     {
         $this->flowAccountIdentifier = $flowAccountIdentifier;
     }
 
-    /**
-     * @return string
-     */
     public function getRefreshToken(): string
     {
         return $this->refreshToken;
     }
 
-    /**
-     * @param string $refreshToken
-     */
     public function setRefreshToken(string $refreshToken): void
     {
         $this->refreshToken = $refreshToken;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAccessToken(): ?string
     {
         return $this->accessToken;
     }
 
-    /**
-     * @param string|null $accessToken
-     */
-    public function setAccessToken($accessToken): void
+    public function setAccessToken(?string $accessToken): void
     {
         $this->accessToken = $accessToken;
     }

--- a/Classes/Domain/Model/ClientSecret.php
+++ b/Classes/Domain/Model/ClientSecret.php
@@ -16,7 +16,6 @@ namespace Flownative\Pixxio\Domain\Model;
 
 use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Annotations\Entity;
-use Neos\Flow\Annotations\Identity;
 
 /**
  * @Entity()
@@ -24,10 +23,14 @@ use Neos\Flow\Annotations\Identity;
 class ClientSecret
 {
     /**
-     * @Identity()
      * @var string
      */
     protected string $flowAccountIdentifier;
+
+    /**
+     * @var string
+     */
+    protected string $assetSourceIdentifier;
 
     /**
      * @ORM\Column(type="text")
@@ -49,6 +52,16 @@ class ClientSecret
     public function setFlowAccountIdentifier(string $flowAccountIdentifier): void
     {
         $this->flowAccountIdentifier = $flowAccountIdentifier;
+    }
+
+    public function getAssetSourceIdentifier(): string
+    {
+        return $this->assetSourceIdentifier;
+    }
+
+    public function setAssetSourceIdentifier(string $assetSourceIdentifier): void
+    {
+        $this->assetSourceIdentifier = $assetSourceIdentifier;
     }
 
     public function getRefreshToken(): string

--- a/Classes/Domain/Repository/ClientSecretRepository.php
+++ b/Classes/Domain/Repository/ClientSecretRepository.php
@@ -23,8 +23,15 @@ use Neos\Flow\Persistence\Repository;
  */
 class ClientSecretRepository extends Repository
 {
-    public function findOneByFlowAccountIdentifier(string $accountIdentifier): ?ClientSecret
+    public function findOneByIdentifiers(string $assetSourceIdentifier, string $accountIdentifier): ?ClientSecret
     {
-        return $this->__call('findOneByFlowAccountIdentifier', [$accountIdentifier]);
+        $query = $this->createQuery();
+        $query = $query->matching(
+            $query->logicalAnd(
+                $query->equals('assetSourceIdentifier', $assetSourceIdentifier),
+                $query->equals('flowAccountIdentifier', $accountIdentifier)
+            )
+        );
+        return $query->execute()->getFirst();
     }
 }

--- a/Classes/Domain/Repository/ClientSecretRepository.php
+++ b/Classes/Domain/Repository/ClientSecretRepository.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Domain\Repository;
 
@@ -22,10 +23,6 @@ use Neos\Flow\Persistence\Repository;
  */
 class ClientSecretRepository extends Repository
 {
-    /**
-     * @param string $accountIdentifier
-     * @return ClientSecret|null
-     */
     public function findOneByFlowAccountIdentifier(string $accountIdentifier): ?ClientSecret
     {
         return $this->__call('findOneByFlowAccountIdentifier', [$accountIdentifier]);

--- a/Classes/Exception/AccessToAssetDeniedException.php
+++ b/Classes/Exception/AccessToAssetDeniedException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Exception;
 

--- a/Classes/Exception/AssetNotFoundException.php
+++ b/Classes/Exception/AssetNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Exception;
 

--- a/Classes/Exception/AuthenticationFailedException.php
+++ b/Classes/Exception/AuthenticationFailedException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Exception;
 

--- a/Classes/Exception/ConnectionException.php
+++ b/Classes/Exception/ConnectionException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Exception;
 

--- a/Classes/Exception/Exception.php
+++ b/Classes/Exception/Exception.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Exception;
 

--- a/Classes/Exception/MissingClientSecretException.php
+++ b/Classes/Exception/MissingClientSecretException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Exception;
 

--- a/Classes/Service/PixxioClient.php
+++ b/Classes/Service/PixxioClient.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Service;
 
@@ -31,32 +32,32 @@ final class PixxioClient
     /**
      * @var Client
      */
-    private $guzzleClient;
+    private Client $guzzleClient;
 
     /**
      * @var string
      */
-    private $apiEndpointUri;
+    private string $apiEndpointUri;
 
     /**
      * @var string
      */
-    private $apiKey;
+    private string $apiKey;
 
     /**
      * @var array
      */
-    private $apiClientOptions;
+    private array $apiClientOptions;
 
     /**
-     * @var string
+     * @var string|null
      */
-    private $accessToken;
+    private ?string $accessToken;
 
     /**
      * @var array
      */
-    private $imageOptions;
+    private array $imageOptions;
 
     /**
      * @var array

--- a/Classes/Service/PixxioClient.php
+++ b/Classes/Service/PixxioClient.php
@@ -278,12 +278,4 @@ final class PixxioClient
             throw new ConnectionException('Retrieving categories failed: ' . $exception->getMessage(), 1642430939);
         }
     }
-
-    /**
-     * @return string
-     */
-    public function getAccessToken(): string
-    {
-        return $this->accessToken;
-    }
 }

--- a/Classes/Service/PixxioServiceFactory.php
+++ b/Classes/Service/PixxioServiceFactory.php
@@ -15,8 +15,6 @@ namespace Flownative\Pixxio\Service;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Persistence\PersistenceManagerInterface;
-use Neos\Flow\Utility\Environment;
 
 /**
  * Factory for the Pixx.io service class
@@ -25,18 +23,6 @@ use Neos\Flow\Utility\Environment;
  */
 class PixxioServiceFactory
 {
-    /**
-     * @Flow\Inject
-     * @var Environment
-     */
-    protected $environment;
-
-    /**
-     * @Flow\Inject
-     * @var PersistenceManagerInterface
-     */
-    protected $persistenceManager;
-
     /**
      * Creates a new PixxioClient instance and authenticates against the Pixx.io API
      *

--- a/Classes/Service/PixxioServiceFactory.php
+++ b/Classes/Service/PixxioServiceFactory.php
@@ -39,14 +39,13 @@ class PixxioServiceFactory
     /**
      * Creates a new PixxioClient instance and authenticates against the Pixx.io API
      *
-     * @param string $accountIdentifier
      * @param string $apiEndpointUri
      * @param string $apiKey
      * @param array $apiClientOptions
      * @param array $imageOptions
      * @return PixxioClient
      */
-    public function createForAccount(string $accountIdentifier, string $apiEndpointUri, string $apiKey, array $apiClientOptions, array $imageOptions)
+    public function createForAccount(string $apiEndpointUri, string $apiKey, array $apiClientOptions, array $imageOptions): PixxioClient
     {
         return new PixxioClient(
             $apiEndpointUri,

--- a/Classes/Service/PixxioServiceFactory.php
+++ b/Classes/Service/PixxioServiceFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Flownative\Pixxio\Service;
 

--- a/Classes/Service/PixxioServiceFactory.php
+++ b/Classes/Service/PixxioServiceFactory.php
@@ -48,12 +48,11 @@ class PixxioServiceFactory
      */
     public function createForAccount(string $accountIdentifier, string $apiEndpointUri, string $apiKey, array $apiClientOptions, array $imageOptions)
     {
-        $client = new PixxioClient(
+        return new PixxioClient(
             $apiEndpointUri,
             $apiKey,
             $apiClientOptions,
             $imageOptions
         );
-        return $client;
     }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -68,8 +68,11 @@ Neos:
           # The icon for the asset source
           icon: 'resource://Flownative.Pixxio/Public/Icons/PixxioWhite.svg'
 
+          # The label for the asset source
+          label: 'pixx.io assets'
+
           # The description for the asset source
-          description: 'Pixxio assets'
+          description: ''
 
   Neos:
     modules:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,9 +1,55 @@
 Flownative:
   Pixxio:
-    mapping:
-      # map "categories" from pixx.io to Neos
-      categoriesMaximumDepth: 10
-      categories: []
+    defaults:
+      assetSourceOptions:
+        # The icon for the asset source
+        icon: 'resource://Flownative.Pixxio/Public/Icons/PixxioWhite.svg'
+
+        # The label for the asset source
+        label: 'pixx.io assets'
+
+        # A description for the asset source, optional
+        description: ''
+
+        # Additional configuration for specific media types
+        mediaTypes:
+          'image/svg+xml':
+            usePixxioThumbnailAsOriginal: true
+          'application/pdf':
+            usePixxioThumbnailAsOriginal: true
+
+        # This plugin can automatically tag files in the pixxio media library
+        # when they are in use, and remove the tag once they are not used anymore
+        autoTagging:
+          enable: false
+          inUseTag: 'used-by-neos'
+
+        # map "categories" from pixx.io to Neos
+        mapping:
+          categoriesMaximumDepth: 10
+          categories: []
+
+        # Image options, are the formats returned for use in the asset properties "thumbnailUri", "previewUri" and "originalUri"
+        # imageOptions parameter are described here: https://tutorial.pixxio.cloud/cgi-bin/api/pixxio-api.pl/documentation/generalInformation/imageOptions
+        # Setting the "crop" parameter, removes the "height" attribute, and creates a non-cropped version
+        imageOptions:
+          thumbnailUri:
+            width: 400
+            height: 400
+            quality: 90
+            crop: false
+          previewUri:
+            width: 1500
+            height: 1500
+            quality: 90
+          originalUri:
+            sizeMax: 1920
+            quality: 90
+
+        # Options for the Guzzle HTTP Client as specified here
+        # see http://docs.guzzlephp.org/en/6.5/request-options.html
+        # Use this to configure custom certificates or to disable cert verification
+        apiClientOptions: {}
 
 Neos:
   Flow:
@@ -11,68 +57,6 @@ Neos:
       routes:
         'Flownative.Pixxio':
           position: 'after Neos.Neos'
-
-  Media:
-    assetSources:
-      'flownative-pixxio':
-        assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
-        assetSourceOptions:
-
-          # The customer-specific endpoint URI pointing to the Pixx.io API:
-          # Example: 'https://flownative.pixxio.media/cgi-bin/api/pixxio-api.pl'
-          apiEndpointUri: ''
-
-          # The API key of this Pixx.io integration.
-          # Please get in touch with Pixx.io support in order to get this key.
-          apiKey: ''
-
-          # Options for the Guzzle HTTP Client as specified here
-          # see http://docs.guzzlephp.org/en/6.5/request-options.html
-          # Use this to configure custom certificates or to disable cert verification
-          apiClientOptions: {}
-
-          # A pixx.io user refresh token which is shared across all editors in
-          # this Neos installation.
-          # sharedRefreshToken: ''
-
-          # Additional configuration for specific media types
-          mediaTypes:
-            'image/svg+xml':
-              usePixxioThumbnailAsOriginal: true
-            'application/pdf':
-              usePixxioThumbnailAsOriginal: true
-
-          # This plugin can automatically tag files in the pixxio media library
-          # when they are in use, and remove the tag once they are not used anymore
-          autoTagging:
-            enable: false
-            inUseTag: 'used-by-neos'
-
-          # Image options, are the formats returned for use in the asset properties "thumbnailUri", "previewUri" and "originalUri"
-          # imageOptions parameter are described here: https://tutorial.pixxio.cloud/cgi-bin/api/pixxio-api.pl/documentation/generalInformation/imageOptions
-          # Setting the "crop" parameter, removes the "height" attribute, and creates a non-cropped version
-          imageOptions:
-            thumbnailUri:
-              width: 400
-              height: 400
-              quality: 90
-              crop: false
-            previewUri:
-              width: 1500
-              height: 1500
-              quality: 90
-            originalUri:
-              sizeMax: 1920
-              quality: 90
-
-          # The icon for the asset source
-          icon: 'resource://Flownative.Pixxio/Public/Icons/PixxioWhite.svg'
-
-          # The label for the asset source
-          label: 'pixx.io assets'
-
-          # The description for the asset source
-          description: ''
 
   Neos:
     modules:

--- a/Migrations/Mysql/Version20180517083014.php
+++ b/Migrations/Mysql/Version20180517083014.php
@@ -1,6 +1,10 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
@@ -13,20 +17,22 @@ class Version20180517083014 extends AbstractMigration
     /**
      * @return string
      */
-    public function getDescription(): string 
+    public function getDescription(): string
     {
-        return '';
+        return 'Introduce Client Secret';
     }
 
     /**
      * @param Schema $schema
      * @return void
-     * @throws \Doctrine\DBAL\DBALException
-     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     * @throws Exception
      */
-    public function up(Schema $schema): void 
+    public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
+        );
 
         $this->addSql('CREATE TABLE flownative_pixxio_domain_model_clientsecret (persistence_object_identifier VARCHAR(40) NOT NULL, flowaccountidentifier VARCHAR(255) NOT NULL, refreshtoken LONGTEXT NOT NULL, accesstoken LONGTEXT DEFAULT NULL, UNIQUE INDEX flow_identity_flownative_pixxio_domain_model_clientsecret (flowaccountidentifier), PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
     }
@@ -34,12 +40,14 @@ class Version20180517083014 extends AbstractMigration
     /**
      * @param Schema $schema
      * @return void
-     * @throws \Doctrine\DBAL\DBALException
-     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     * @throws Exception
      */
-    public function down(Schema $schema): void 
+    public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
+        );
 
         $this->addSql('DROP TABLE flownative_pixxio_domain_model_clientsecret');
     }

--- a/Migrations/Mysql/Version20240910102102.php
+++ b/Migrations/Mysql/Version20240910102102.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add asset source identifier to ClientSecret
+ */
+final class Version20240910102102 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add asset source identifier to ClientSecret';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
+        );
+
+        $this->addSql('DROP INDEX flow_identity_flownative_pixxio_domain_model_clientsecret ON flownative_pixxio_domain_model_clientsecret');
+        $this->addSql('ALTER TABLE flownative_pixxio_domain_model_clientsecret ADD assetsourceidentifier VARCHAR(255) NOT NULL');
+        $this->addSql("UPDATE flownative_pixxio_domain_model_clientsecret SET assetsourceidentifier = 'flownative-pixxio' WHERE assetsourceidentifier = ''");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
+        );
+
+        $this->addSql('ALTER TABLE flownative_pixxio_domain_model_clientsecret DROP assetsourceidentifier');
+        $this->addSql('CREATE UNIQUE INDEX flow_identity_flownative_pixxio_domain_model_clientsecret ON flownative_pixxio_domain_model_clientsecret (flowaccountidentifier)');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -39,34 +39,21 @@ The API access is configured by three components:
 
 1. a setting which contains the customer-specific service endpoint URL
 2. a setting providing the pixx.io API key
-3. a setting providing the pixx.io user refresh token
+3. a setting providing a shared pixx.io user refresh token
 
 **To get the needed values for API endpoint and API key, please contact your pixx.io support contact.**
 
-First define the customer-specific service endpoint by adding the URL to your settings:
+Using those values configure an asset source by adding this to your settings:
 
 ```yaml
 Neos:
   Media:
     assetSources:
-      'flownative-pixxio':
+      # an identifier for your asset source, up to you
+      'acme-pixxio':
         assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
         assetSourceOptions:
-          apiEndpointUri: 'https://flownative.pixxio.media/cgi-bin/api/pixxio-api.pl'
-```
-
-You will likely just replace "flownative" by our own subdomain.
-
-Next, add the pixx.io API key and the refresh token of the pixx.io user you want to connect with Neos:
-
-```yaml
-Neos:
-  Media:
-    assetSources:
-      'flownative-pixxio':
-        assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
-        assetSourceOptions:
-          apiEndpointUri: 'https://flownative.pixxio.media/cgi-bin/api/pixxio-api.pl'
+          apiEndpointUri: 'https://acme.pixxio.media/cgi-bin/api/pixxio-api.pl'
           apiKey: 'abcdef123456789'
           sharedRefreshToken: 'A3ZezMq6Q24X314xbaiq5ewNE5q4Gt'
 ```
@@ -82,6 +69,24 @@ message with further details).
 
 ## Additional configuration options
 
+Defaults for the described settings can be found (and adjusted) in `Flownative.Pixxio.defaults.assetSourceOptions`.
+
+### Label & description
+
+You can configure a custom label and description for the asset source like this:
+
+```yaml
+Neos:
+  Media:
+    assetSources:
+      'acme-pixxio':
+        assetSourceOptions:
+          label: 'ACME assets'
+          description: 'Our custom pixx.io assets source'
+```
+
+### Additional configuration for specific media types
+
 During import, Neos tries to use a medium-sized version of the original instead of the high resolution file uploaded to
 pixx.io. This greatly improves import speed and produces good results in most cases. Furthermore, this way some formats,
 like Adobe Photoshop, can be used seamlessly in Neos without the need to prior converting them into a web-compatible image
@@ -94,8 +99,7 @@ SVG or PDF are imported this way. You can add more types through the similar ent
 Neos:
   Media:
     assetSources:
-      'flownative-pixxio':
-        assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
+      'acme-pixxio':
         assetSourceOptions:
           mediaTypes:
             'image/svg+xml':
@@ -104,16 +108,16 @@ Neos:
               usePixxioThumbnailAsOriginal: true
 ```
 
-Sometimes the API Client needs additional configuration for the tls connection
-like custom timeouts or certificates.
+### Custom API client options
+
+Sometimes the API Client needs additional configuration for the tls connection like custom timeouts or certificates.
 See: http://docs.guzzlephp.org/en/6.5/request-options.html
 
 ```yaml
 Neos:
   Media:
     assetSources:
-      'flownative-pixxio':
-        assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
+      'acme-pixxio':
         assetSourceOptions:
           apiClientOptions:
             'verify': '/path/to/cert.pem'
@@ -126,34 +130,23 @@ Via configuration, you can set what dimensions the returned images must have. Th
  * `previewUri` used in the detail page of a asset
  * `originalUri` used for downloading the asset
 
-The configuration is by default
+Each can be overridden from your own configuration, by addressing the specific preset key.
+
+By default, the assets from Pixx.io is returned in a cropped format. When this is the case,
+a editor can't see if a asset is horizontal or vertical, when looking in the Media Browser list.
+By setting `crop: false` the image will be returned in a not-cropped version, and it's visible
+for the editor, to see the assets orientation.
 
 ```yaml
 Neos:
   Media:
     assetSources:
-      'flownative-pixxio':
-        assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
+      'acme-pixxio':
         assetSourceOptions:
           imageOptions:
             thumbnailUri:
-              width: 400
-              height: 400
-              quality: 90
               crop: false
-            previewUri:
-              width: 1500
-              height: 1500
-              quality: 90
-            originalUri:
-              sizeMax: 1920
-              quality: 90
 ```
-
-Each imageOptions can be overridden from your own packages configuration, by addressing the specific preset key.
-
-By default, the assets from Pixx.io is returned in a cropped format. When this is the case, a editor can't see if a asset is horizontal or vertical, when looking in the Media Browser list.
-By setting `crop: false` the image will be returned in a not-cropped version, and it's visible for the editor, to see the assets orientation
 
 ## Cleaning up unused assets
 
@@ -165,14 +158,14 @@ storage. While this does not happen automatically, it can be easily automated by
 In order to clean up unused assets, simply run the following command as often as you like:
 
 ```bash
-./flow media:removeunused --asset-source flownative-pixxio
+./flow media:removeunused --asset-source acme-pixxio
 ```
 
 If you'd rather like to invoke this command through a cron-job, you can add two additional flags which make this
 command non-interactive:
 
 ```bash
-./flow media:removeunused --quiet --assume-yes --asset-source flownative-pixxio
+./flow media:removeunused --quiet --assume-yes --asset-source acme-pixxio
 ```
 
 ## Auto-Tagging
@@ -188,12 +181,12 @@ Auto-tagging is configured as follows:
 Neos:
   Media:
     assetSources:
-      'flownative-pixxio':
-        assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
+      'acme-pixxio':
         assetSourceOptions:
           autoTagging:
             enable: true
-            inUseTag: 'your-custom-tag'
+            # optional, used-by-neos is the default tag
+            inUseTag: 'used-by-neos'
 ```
 
 Since Neos currently cannot handle auto-tagging reliably during runtime, the job must be done through a
@@ -201,9 +194,9 @@ command line command. Simply run the following command for tagging new assets an
 assets which are not in use anymore:
 
 ```
-./flow pixxio:tagusedassets
+./flow pixxio:tagusedassets --asset-source acme-pixxio
 
-Tagging used assets of asset source "flownative-pixxio" via Pixxio API:
+Tagging used assets of asset source "acme-pixxio" via Pixxio API:
   (tagged)  dana-devolk-1348553-unsplash 358 (1)
    tagged   azamat-zhanisov-1348039-unsplash 354 (1)
   (tagged)  tim-foster-1345174-unsplash 373 (1)
@@ -227,48 +220,38 @@ pixx.io offers categories to organize assets in a folder-like structure. Those
 can be mapped to asset collections and tags in Neos, to make them visible for
 the  users.
 
----
-**NOTE**  
-The pixx.io asset source declares itself read-only. Neos does not show asset
-collections in the UI for read-only asset sources. This has been changed for
-Neos 7.3.0 and up with https://github.com/neos/neos-development-collection/pull/3481
-
- If you want to use this feature with older Neos versions, you can use the PR with
- [cweagans/composer-patches](https://github.com/cweagans/composer-patches#readme)
- or copy the adjusted template into your project and use `Views.yaml` to activate it.
----
-
 The configuration for the category import looks like this:
 
 ```yaml
-Flownative:
-  Pixxio:
-    mapping:
-      # map "categories" from pixx.io to Neos
-      categoriesMaximumDepth: 2         # only include the first two levels of categories
-      categories:
-        'People/Employees':
-          asAssetCollection: false      # ignore this category, put more specific patterns first
-        'People*':                      # the category "path" in pixx.io, shell-style globbing is supported
-          asAssetCollection: true       # map to an asset collection named after the category
+Neos:
+  Media:
+    assetSources:
+      'acme-pixxio':
+        assetSourceOptions:
+          mapping:
+            # map "categories" from pixx.io to Neos
+            categoriesMaximumDepth: 2         # only include the first two levels of categories (10 is default)
+            categories:
+              'People/Employees':
+                asAssetCollection: false      # ignore this category, put more specific patterns first
+              'People*':                      # the category "path" in pixx.io, shell-style globbing is supported
+                asAssetCollection: true       # map to an asset collection named after the category
 ```
 
-- The key used is the category identifier from pixx.io as used in the API,
-  without leading slash
-- `asAssetCollection` set to `true` exposes the category as an asset
-  collection named like the category.
+- The key used is the category identifier from pixx.io as used in the API, without leading slash
+- `asAssetCollection` set to `true` exposes the category as an asset collection named like the category.
 
 Afterwards, run the following command to update the asset collections, ideally
 in a cronjob to keep things up-to-date:
 
 ```bash
-./flow pixxio:importcategoriesascollections
+./flow pixxio:importcategoriesascollections --asset-source acme-pixxio
 ```
 
 To check what a given category would import, you can use a verbose dry-run:
 
 ```bash
-$ ./flow pixxio:importcategoriesascollections --quiet 0 --dry-run 1
+$ ./flow pixxio:importcategoriesascollections --asset-source acme-pixxio --quiet 0 --dry-run 1
 Importing categories as asset collections via pixx.io API
 o Dokumentation
 = Kunde A

--- a/README.md
+++ b/README.md
@@ -209,9 +209,11 @@ command. It's important to run the `removeunused`-command *after* the tagging co
 images will not be untagged in the pixx.io media library.
 
 ---
+
 **NOTE**  
 At this point, the auto-tagging feature is not really optimized for performance. The command merely
 iterates over all assets which were imported from pixx.io and checks if tags need to be updated.
+
 ---
 
 ### Category mapping from pixx.io to Neos

--- a/Resources/Private/Templates/Pixxio/Index.html
+++ b/Resources/Private/Templates/Pixxio/Index.html
@@ -1,46 +1,56 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 <div class="neos-content neos-container-fluid">
     <h2>{neos:backend.translate(id: 'pixxioConnectionSettings', source: 'Main', package: 'Flownative.Pixxio')}</h2>
-    <br />
-    <f:form action="updateRefreshToken" method="post">
-        <div class="neos-row-fluid">
-            <div class="neos-span6">
-                <f:if condition="{sharedRefreshToken}">
-                    <f:then>
-                        <p>{neos:backend.translate(id: 'sharedRefreshTokenExists', source: 'Main', package: 'Flownative.Pixxio')}</p>
-                    </f:then>
-                    <f:else>
-                        <p>{neos:backend.translate(id: 'providePersonalRefreshToken', source: 'Main', package: 'Flownative.Pixxio')}<br />
-                            {neos:backend.translate(id: 'whereToFindRefreshTokenHint', source: 'Main', package: 'Flownative.Pixxio')}</p>
-                    </f:else>
-                </f:if>
-                <fieldset>
-                    <div class="neos-control-group">
-                        <label class="neos-control-label" for="apiEndpointUri">{neos:backend.translate(id: 'apiEndpointUri', source: 'Main', package: 'Flownative.Pixxio')}</label>
-                        <div class="neos-controls">
-                            <f:form.textfield name="pixxioUrl" id="apiEndpointUri" class="neos-span12" value="{apiEndpointUri}" readonly="true"/>
+    <br/>
+    <f:for each="{assetSourcesData}" as="assetSourceData" key="assetSourceIdentifier">
+        <f:form action="updateRefreshToken" method="post">
+            <f:form.hidden name="assetSourceIdentifier" value="{assetSourceIdentifier}"/>
+            <div class="neos-row-fluid">
+                <div class="neos-span6">
+                    <br/>
+                    <h3>{assetSourceData.label} – {assetSourceIdentifier}</h3>
+                    <f:if condition="{assetSourceData.description}">
+                    <br/>
+                    <i>{assetSourceData.description}</i><br/>
+                    </f:if>
+                    <br/>
+                    <f:if condition="{assetSourceData.sharedRefreshToken}">
+                        <f:then>
+                            <p><i class="fas fa-info"></i> {neos:backend.translate(id: 'sharedRefreshTokenExists', source: 'Main', package: 'Flownative.Pixxio')}</p>
+                        </f:then>
+                        <f:else>
+                            <p><i class="fas fa-exclamation-circle"></i> {neos:backend.translate(id: 'providePersonalRefreshToken', source: 'Main', package: 'Flownative.Pixxio')}<br />
+                                {neos:backend.translate(id: 'whereToFindRefreshTokenHint', source: 'Main', package: 'Flownative.Pixxio')}</p>
+                        </f:else>
+                    </f:if>
+                    <fieldset>
+                        <div class="neos-control-group">
+                            <label class="neos-control-label" for="apiEndpointUri">{neos:backend.translate(id: 'apiEndpointUri', source: 'Main', package: 'Flownative.Pixxio')}</label>
+                            <div class="neos-controls">
+                                <f:form.textfield name="pixxioUrl" id="apiEndpointUri" class="neos-span12" value="{assetSourceData.apiEndpointUri}" readonly="true"/>
+                            </div>
                         </div>
-                    </div>
-                    <div class="neos-control-group">
-                        <label class="neos-control-label" for="refreshToken">{neos:backend.translate(id: 'personalRefreshToken', source: 'Main', package: 'Flownative.Pixxio')}</label>
-                        <div class="neos-controls">
-                            <f:form.textfield name="refreshToken" id="refreshToken" class="neos-span12" value="{refreshToken}" />
+                        <div class="neos-control-group">
+                            <label class="neos-control-label" for="refreshToken">{neos:backend.translate(id: 'personalRefreshToken', source: 'Main', package: 'Flownative.Pixxio')}</label>
+                            <div class="neos-controls">
+                                <f:form.textfield name="refreshToken" id="refreshToken" class="neos-span12" value="{assetSourceData.refreshToken}" />
+                            </div>
                         </div>
-                    </div>
-                    <div class="neos-control-group">
-                        <div class="neos-controls">
-                            <f:form.submit value="{neos:backend.translate(id: 'updateRefreshToken', source: 'Main', package: 'Flownative.Pixxio')}" class="neos-button neos-button-primary" />
+                        <div class="neos-control-group">
+                            <div class="neos-controls">
+                                <f:form.submit value="{neos:backend.translate(id: 'updateRefreshToken', source: 'Main', package: 'Flownative.Pixxio')}" class="neos-button neos-button-primary" />
+                            </div>
                         </div>
-                    </div>
-                </fieldset>
-                <f:if condition="{connectionSucceeded}">
-                    <p><i class="fa fa-info"></i>{neos:backend.translate(id: 'connectionSucceeded', source: 'Main', package: 'Flownative.Pixxio')}</p>
-                </f:if>
-                <f:if condition="{authenticationError}">
-                    <p><i class="fa fa-exclamation-triangle"></i> {authenticationError}</p>
-                </f:if>
+                    </fieldset>
+                    <f:if condition="{assetSourceData.connectionSucceeded}">
+                        <p><i class="fa fa-info"></i>{neos:backend.translate(id: 'connectionSucceeded', source: 'Main', package: 'Flownative.Pixxio')}</p>
+                    </f:if>
+                    <f:if condition="{assetSourceData.authenticationError}">
+                        <p><i class="fa fa-exclamation-triangle"></i> {assetSourceData.authenticationError}</p>
+                    </f:if>
+                </div>
             </div>
-        </div>
-    </f:form>
-
+        </f:form>
+        <hr/>
+    </f:for>
 </div>

--- a/Tests/Unit/PixxioCommandControllerTest.php
+++ b/Tests/Unit/PixxioCommandControllerTest.php
@@ -1,28 +1,41 @@
 <?php
 namespace Flownative\Pixxio\Tests\Unit;
 
+use Flownative\Pixxio\AssetSource\PixxioAssetSource;
 use Flownative\Pixxio\Command\PixxioCommandController;
 use Neos\Flow\Tests\UnitTestCase;
-use Neos\Flow\Aop;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcase for the command controller
  */
 class PixxioCommandControllerTest extends UnitTestCase
 {
-    protected static $mapping = [
-        'categoriesMaximumDepth' => 2,
-        'categories' => [
-            'home*' => ['asAssetCollection' => false],
-            'Kunde A*' => ['asAssetCollection' => false],
-            '*' => ['asAssetCollection' => true]
+    protected static $assetSourceOptions = [
+        'mapping' => [
+            'categoriesMaximumDepth' => 2,
+            'categories' => [
+                'home*' => ['asAssetCollection' => false],
+                'Kunde A*' => ['asAssetCollection' => false],
+                '*' => ['asAssetCollection' => true]
+            ],
         ],
     ];
 
+    /**
+     * @var MockObject|PixxioAssetSource
+     */
+    private $mockAssetSource;
+
+    private MockObject|PixxioCommandController $commandController;
+
     public function setUp(): void
     {
-        $this->mockCommandController = $this->getAccessibleMock(PixxioCommandController::class, ['dummy']);
-        $this->mockCommandController->_set('mapping', self::$mapping);
+        $this->commandController = new PixxioCommandController();
+
+//        $this->mockAssetSource = $this->getAccessibleMock(PixxioAssetSource::class, ['getAssetSourceOptions']);
+        $this->mockAssetSource = $this->getMockBuilder(PixxioAssetSource::class)->disableOriginalConstructor()->onlyMethods(['getAssetSourceOptions'])->getMock();
+        $this->mockAssetSource->method('getAssetSourceOptions')->willReturn(self::$assetSourceOptions);
     }
 
     public function categoriesMappingProvider(): array
@@ -51,6 +64,6 @@ class PixxioCommandControllerTest extends UnitTestCase
      */
     public function shouldBeImportedAsAssetCollectionWorks(string $category, bool $expected): void
     {
-        self::assertSame($expected, $this->mockCommandController->_call('shouldBeImportedAsAssetCollection', $category), $category);
+        self::assertSame($expected, $this->commandController->shouldBeImportedAsAssetCollection($this->mockAssetSource, $category), $category);
     }
 }

--- a/Tests/Unit/PixxioCommandControllerTest.php
+++ b/Tests/Unit/PixxioCommandControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Flownative\Pixxio\Tests\Unit;
 
 use Flownative\Pixxio\AssetSource\PixxioAssetSource;
@@ -11,7 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class PixxioCommandControllerTest extends UnitTestCase
 {
-    protected static $assetSourceOptions = [
+    protected static array $assetSourceOptions = [
         'mapping' => [
             'categoriesMaximumDepth' => 2,
             'categories' => [
@@ -29,7 +31,7 @@ class PixxioCommandControllerTest extends UnitTestCase
 
     private MockObject|PixxioCommandController $commandController;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->commandController = new PixxioCommandController();
 

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,9 @@
     "name": "flownative/neos-pixxio",
     "license": "MIT",
     "require": {
-        "neos/flow": "^6.3 || ^7.0 || ^8.0 || dev-master",
-        "neos/media": "^5.3 || ^7.0 || ^8.0 || dev-master",
+        "php": "^8.0",
+        "neos/flow": "^7.3 || ^8.0",
+        "neos/media": "^7.3 || ^8.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "behat/transliterator": "~1.0"
     },


### PR DESCRIPTION
This allows to (properly) use two (or more) pixx.io asset sources at the same time.

Example settings:

```yaml
Neos:
  Media:
    assetSources:
      'acme-pixxio':
        assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
        assetSourceOptions:
          apiEndpointUri: 'https://acme.pixxio.media/cgi-bin/api/pixxio-api.pl'
          apiKey: '1234…7890'
          sharedRefreshToken: 'abcd…wxyz'
          label: 'ACME assets'
      'other-pixxio':
        assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
        assetSourceOptions:
          apiEndpointUri: 'https://foo.pixxio.media/cgi-bin/api/pixxio-api.pl'
          apiKey: '1234…7890'
          sharedRefreshToken: 'abcd…wxyz'
          label: 'Shared assets'
```

With this PR, the default settings below `flownative-pixxio` are dropped. You can continue to use that identifier like before.

**BREAKING CHANGE**

If you use category mapping, you **must** move the `mapping` setting into the asset source options or into the new `defaults`, if you want to share them between multiple asset sources.