### PR TITLE
FEATURE: Allow to set custom label for asset source

### DIFF
--- a/Classes/AssetSource/PixxioAssetSource.php
+++ b/Classes/AssetSource/PixxioAssetSource.php
@@ -98,6 +98,11 @@ class PixxioAssetSource implements AssetSourceInterface
     private $assetSourceOptions;
 
     /**
+     * @var string
+     */
+    protected $label = 'pixx.io';
+
+    /**
      * @param string $assetSourceIdentifier
      * @param array $assetSourceOptions
      */
@@ -161,6 +166,9 @@ class PixxioAssetSource implements AssetSourceInterface
                         }
                     }
                 break;
+                case 'label':
+                    $this->label = $optionValue;
+                break;
                 default:
                     throw new \InvalidArgumentException(sprintf('Unknown asset source option "%s" specified for Pixx.io asset source "%s". Please check your settings.', $optionName, $assetSourceIdentifier), 1525790910);
             }
@@ -190,7 +198,7 @@ class PixxioAssetSource implements AssetSourceInterface
      */
     public function getLabel(): string
     {
-        return 'pixx.io';
+        return $this->label;
     }
 
     /**

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -10,6 +10,8 @@ Neos:
       'flownative-pixxio':
         assetSource: 'Flownative\Pixxio\AssetSource\PixxioAssetSource'
         assetSourceOptions:
+          # A custom label for this Pixx.io asset source
+          label: 'pixx.io'
 
           # The customer-specific endpoint URI pointing to the Pixx.io API:
           # Example: 'https://flownative.pixxio.media/cgi-bin/api/pixxio-api.pl'


### PR DESCRIPTION
Example:

```yaml
Neos:
  Media:
    assetSources:
      'flownative-pixxio':
        assetSourceOptions:
          label: 'My pixx.io library'
```