### PR TITLE
Relax version constraint on PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "name": "flownative/neos-pixxio",
   "license": "MIT",
   "require": {
-    "php": "^7.4",
+    "php": "^7.3",
     "ext-json": "*",
     "neos/flow": "5.*",
     "neos/media": "4.*",


### PR DESCRIPTION
Well, if it has to be PHP 7, at can even be PHP 7.3…