### PR TITLE
Fix sortBy property name to sortby in PixxioClient

### DIFF
--- a/Classes/Service/PixxioClient.php
+++ b/Classes/Service/PixxioClient.php
@@ -237,12 +237,12 @@ final class PixxioClient
         }
 
         if (isset($orderings['resource.filename'])) {
-            $options->sortBy = 'fileName';
+            $options->sortby = 'fileName';
             $options->sortDirection = ($orderings['resource.filename'] === SupportsSortingInterface::ORDER_DESCENDING) ? 'descending' : 'ascending';
         }
 
         if (isset($orderings['lastModified'])) {
-            $options->sortBy = 'uploadDate';
+            $options->sortby = 'uploadDate';
             $options->sortDirection = ($orderings['lastModified'] === SupportsSortingInterface::ORDER_DESCENDING) ? 'descending' : 'ascending';
         }
 


### PR DESCRIPTION
The request that goes out to pixxio to receive the files uses a `sortBy` parameter, just like it says in the documentation.
https://api.pixxio.com/docs#tag/Files/operation/FilesGet


Strangely, this returns an error like this:

```json
{
    "success": "false",
    "status": "400",
    "message": "Bad Request",
    "errorcode": "5006",
    "help": "The specified sortBy is invalid.",
    "statusCode": 500,
    "errorDescription": {},
    "stackTrace": null
}
```

Writing "sortBy" in lowercase fixes the error and still retains the sorting.

It's also possible that this is entirely a bug from the pixxio API and this PR is not needed.
