### PR TITLE
Fix error with update of copyright notice

### DIFF
--- a/Classes/Command/PixxioCommandController.php
+++ b/Classes/Command/PixxioCommandController.php
@@ -169,7 +169,7 @@ class PixxioCommandController extends CommandController
 
             if ($newCopyrightNotice !== $asset->getCopyrightNotice()) {
                 !$quiet && $this->outputLine('      <success>New copyright:   %s</success>', [$newCopyrightNotice]);
-                $asset->setTitle($newCopyrightNotice);
+                $asset->setCopyrightNotice($newCopyrightNotice);
                 $assetModified = true;
             }
 


### PR DESCRIPTION
The copyright notice was written to the title when updating asset metadata using the `pixxio:updatemetadata` CLI command.

Fixes #27