### PR TITLE
Fix uninitialized directory filter before usage

### DIFF
--- a/Classes/AssetSource/PixxioAssetProxyRepository.php
+++ b/Classes/AssetSource/PixxioAssetProxyRepository.php
@@ -38,7 +38,7 @@ class PixxioAssetProxyRepository implements AssetProxyRepositoryInterface, Suppo
 
     private PixxioAssetSource $assetSource;
 
-    protected ?int $directoryFilter;
+    protected ?int $directoryFilter = null;
 
     private string $assetTypeFilter = 'All';
 


### PR DESCRIPTION
**Context:**
Exceptions occurred in `LinkEditor` when referencing document nodes due to uninitialized `$this->directoryFilter`.

**Changes:**
- Ensure `$this->directoryFilter` is initialized before usage in `findXXX()` methods.
- Resolves failures in `Neos.Neos/Inspector/Editors/LinkEditor`.