### PR TITLE
Fix issues with Flow 7.x

### DIFF
--- a/Classes/AssetSource/PixxioAssetProxyQuery.php
+++ b/Classes/AssetSource/PixxioAssetProxyQuery.php
@@ -44,11 +44,13 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
 
     /**
      * @Inject
+      * @var LoggerInterface
      */
     protected LoggerInterface $logger;
 
     /**
      * @Inject
+     * @var ThrowableStorageInterface
      */
     protected ThrowableStorageInterface $throwableStorage;
 

--- a/Classes/AssetSource/PixxioAssetSource.php
+++ b/Classes/AssetSource/PixxioAssetSource.php
@@ -28,8 +28,9 @@ class PixxioAssetSource implements AssetSourceInterface
 
     /**
      * @Flow\Inject
+     * @var ResourceManager
      */
-    protected ResourceManager $resourceManager;
+    protected ?ResourceManager $resourceManager = null;
 
     /**
      * @Flow\InjectConfiguration(path="defaults", package="Flownative.Pixxio")


### PR DESCRIPTION
Flow 7.x still needs
- `@var` to avoid `Malformed DocComent block for a property` errors
- typed propeeties to be  nullable for DI

Fixes #36