### PR TITLE
BUGFIX: Add "includeSubdirectories" flag to directories filter to restore previous behavior

### DIFF
--- a/Classes/Service/PixxioClient.php
+++ b/Classes/Service/PixxioClient.php
@@ -149,7 +149,7 @@ final class PixxioClient
         $filters = [];
 
         if ($directoryFilter !== null) {
-            $filters[] = ['filterType' => 'directory', 'directoryID' => $directoryFilter];
+            $filters[] = ['filterType' => 'directory', 'directoryID' => $directoryFilter, 'includeSubdirectories' =>  true];
         }
         if ($formatType !== '') {
             $filters[] = ['filterType' => 'fileType', 'fileType' => $formatType];


### PR DESCRIPTION
The "includeSubdirectories" flag is set to ensure that also subdirectories of the current directory are included in the result.

Resolves: #41