### PR TITLE
Switch pixx.io file search to cursor-based pagination

### DIFF
--- a/Classes/AssetSource/PixxioAssetProxyQuery.php
+++ b/Classes/AssetSource/PixxioAssetProxyQuery.php
@@ -17,7 +17,9 @@ namespace Flownative\Pixxio\AssetSource;
 use Flownative\Pixxio\Exception\AuthenticationFailedException;
 use Flownative\Pixxio\Exception\ConnectionException;
 use Flownative\Pixxio\Exception\Exception;
+use Neos\Cache\Exception as CacheException;
 use Neos\Cache\Frontend\StringFrontend;
+use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Annotations\Inject;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
@@ -34,7 +36,7 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
 
     private string $assetTypeFilter = 'All';
 
-    private ?int $directoryFilter;
+    private ?int $directoryFilter = null;
 
     private array $orderings = [];
 
@@ -44,7 +46,7 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
 
     /**
      * @Inject
-      * @var LoggerInterface
+     * @var LoggerInterface
      */
     protected LoggerInterface $logger;
 
@@ -55,6 +57,8 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
     protected ThrowableStorageInterface $throwableStorage;
 
     protected null|StringFrontend|DependencyProxy $assetProxyCache = null;
+
+    protected null|VariableFrontend|DependencyProxy $pageCursorCache = null;
 
     public function __construct(PixxioAssetSource $assetSource)
     {
@@ -114,7 +118,10 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
     public function count(): int
     {
         try {
-            $response = $this->sendSearchRequest(1, []);
+            // The total quantity is independent of the current offset, so we always read it
+            // from the first page (which needs no cursor). A page size of 1 keeps this cheap.
+            [$formatType, $fileTypes] = $this->resolveTypeFilters();
+            $response = $this->assetSource->getPixxioClient()->search($this->searchTerm, $formatType, $fileTypes, $this->directoryFilter, '', 1, []);
             if (!isset($response->quantity)) {
                 if (isset($response->errorMessage)) {
                     $message = $this->throwableStorage->logThrowable(new ConnectionException('Query to pixx.io failed: ' . $response->errorMessage, 1526629493));
@@ -171,11 +178,70 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
     }
 
     /**
+     * Fetches the result page covering the current offset.
+     *
+     * The pixx.io API only supports cursor-based pagination for GET /files: to load page N
+     * the "cursor" returned by page N-1 is required. To bridge the offset-based Neos query
+     * interface we keep a short-lived cache of already discovered cursors per query. Sequential
+     * forward paging (the common case) therefore costs a single request per page, while jumping
+     * to a not-yet-visited page walks the cursors forward from the nearest known position.
+     *
      * @throws AuthenticationFailedException
      * @throws ConnectionException
      * @throws \JsonException
      */
     private function sendSearchRequest(int $limit, array $orderings): object
+    {
+        [$formatType, $fileTypes] = $this->resolveTypeFilters();
+        $client = $this->assetSource->getPixxioClient();
+
+        $targetPage = $limit > 0 ? intdiv($this->offset, $limit) : 0;
+
+        // The first page is requested without a cursor.
+        if ($targetPage === 0) {
+            $response = $client->search($this->searchTerm, $formatType, $fileTypes, $this->directoryFilter, '', $limit, $orderings);
+            $this->rememberPageCursors($limit, $orderings, [1 => $response->cursor ?? null]);
+            return $response;
+        }
+
+        $cacheKey = $this->pageCursorCacheKey($limit, $orderings);
+        $cursors = $this->pageCursorCache->get($cacheKey) ?: [];
+
+        // Start from the nearest known cursor (page 0 needs none) and walk forward.
+        $page = $targetPage;
+        while ($page > 0 && !array_key_exists($page, $cursors)) {
+            $page--;
+        }
+        $cursor = $page === 0 ? '' : $cursors[$page];
+
+        while (true) {
+            $response = $client->search($this->searchTerm, $formatType, $fileTypes, $this->directoryFilter, $cursor, $limit, $orderings);
+            $nextCursor = $response->cursor ?? null;
+            if ($nextCursor !== null) {
+                $cursors[$page + 1] = $nextCursor;
+            }
+            if ($page === $targetPage) {
+                break;
+            }
+            if ($nextCursor === null) {
+                // The requested page lies beyond the last page, so there are no results for it.
+                $response->files = [];
+                break;
+            }
+            $cursor = $nextCursor;
+            $page++;
+        }
+
+        $this->rememberPageCursors($limit, $orderings, $cursors);
+        return $response;
+    }
+
+    /**
+     * Maps the asset type filter to the pixx.io format type and file extensions.
+     *
+     * @return array{0: string, 1: array<string>}
+     */
+    private function resolveTypeFilters(): array
     {
         $formatType = '';
         $fileTypes = [];
@@ -194,6 +260,42 @@ final class PixxioAssetProxyQuery implements AssetProxyQueryInterface
                 break;
         }
 
-        return $this->assetSource->getPixxioClient()->search($this->searchTerm, $formatType, $fileTypes, $this->directoryFilter, $this->offset, $limit, $orderings);
+        return [$formatType, $fileTypes];
+    }
+
+    /**
+     * Builds a cache identifier covering everything that influences the result set and its ordering.
+     *
+     * @throws \JsonException
+     */
+    private function pageCursorCacheKey(int $limit, array $orderings): string
+    {
+        return sha1(json_encode([
+            $this->assetSource->getIdentifier(),
+            $this->searchTerm,
+            $this->assetTypeFilter,
+            $this->directoryFilter,
+            $orderings,
+            $limit,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param array<int, string|null> $cursors
+     * @throws \JsonException
+     */
+    private function rememberPageCursors(int $limit, array $orderings, array $cursors): void
+    {
+        // Only actual cursor tokens are worth keeping; the first page never needs one.
+        $cursors = array_filter($cursors, static fn ($cursor) => $cursor !== null);
+        if ($cursors === []) {
+            return;
+        }
+        try {
+            // Caching cursors is a best-effort optimisation; a cache failure must not break the search.
+            $this->pageCursorCache->set($this->pageCursorCacheKey($limit, $orderings), $cursors);
+        } catch (CacheException $exception) {
+            $this->logger->warning('Could not cache pixx.io page cursors: ' . $exception->getMessage(), LogEnvironment::fromMethodName(__METHOD__));
+        }
     }
 }

--- a/Classes/Service/PixxioClient.php
+++ b/Classes/Service/PixxioClient.php
@@ -138,11 +138,16 @@ final class PixxioClient
      * @throws ConnectionException
      * @throws \JsonException
      */
-    public function search(string $queryExpression, string $formatType, array $fileTypes, int $directoryFilter = null, int $offset = 0, int $limit = 50, array $orderings = []): object
+    public function search(string $queryExpression, string $formatType, array $fileTypes, int $directoryFilter = null, string $pageCursor = '', int $limit = 50, array $orderings = []): object
     {
         $options = new \stdClass();
         $options->pageSize = $limit;
-        $options->page = (int)($offset / $limit + 1);
+        // Cursor-based pagination: the first page is requested without a cursor, subsequent
+        // pages use the "cursor" value returned in the previous response. The deprecated
+        // offset-based "page" parameter must not be used anymore (removed by pixx.io on 2026-06-10).
+        if ($pageCursor !== '') {
+            $options->pageCursor = $pageCursor;
+        }
         $options->previewFileOptions = json_encode($this->imageOptions, JSON_THROW_ON_ERROR);
         $options->responseFields = json_encode(self::$fields, JSON_THROW_ON_ERROR);
 

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -9,3 +9,9 @@ Flownative_Pixxio_Directories:
   backend: Neos\Cache\Backend\FileBackend
   backendOptions:
     defaultLifetime: 0
+
+Flownative_Pixxio_PageCursors:
+  frontend: Neos\Cache\Frontend\VariableFrontend
+  backend: Neos\Cache\Backend\FileBackend
+  backendOptions:
+    defaultLifetime: 60

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -24,3 +24,10 @@ Flownative\Pixxio\AssetSource\PixxioAssetProxyQuery:
         arguments:
           1:
             value: Flownative_Pixxio_AssetProxy
+    pageCursorCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Flownative_Pixxio_PageCursors


### PR DESCRIPTION
pixx.io removed the offset-based "page" parameter from GET /files on 2026-06-10 in favour of cursor-based pagination, where loading page N requires the cursor returned by page N-1.

To bridge this to the offset-based Neos asset query interface, the client now passes a page cursor instead of an offset, and the query keeps a short-lived per-query cache of discovered cursors. Sequential forward paging costs one request per page, while jumping to a not-yet- visited page walks the cursors forward from the nearest known one.

The total quantity for count() is now read (directly) from the first page, which needs no cursor.

Fixes #42